### PR TITLE
feat: add RabbitMQ circuit breaker outbox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,7 +302,7 @@ services:
     depends_on:
       - gateway
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8080/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/services/gateway/nginx.conf
+++ b/services/gateway/nginx.conf
@@ -3,22 +3,22 @@ events {
 }
 
 http {
-    resolver 127.0.0.11 valid=10s;
+    resolver 127.0.0.11 valid=10s ipv6=off;
     keepalive_timeout 65;
-
-    upstream auth_svc        { server auth-service:8081; }
-    upstream quest_svc       { server quest-service:8082; }
-    upstream project_svc     { server project-service:8083; }
-    upstream progression_svc { server progression-service:8084; }
-    upstream stats_svc       { server stats-service:8085; }
-    upstream admin_svc       { server admin-service:8086; }
 
     server {
         listen 8080;
 
+        set $auth_svc        "auth-service:8081";
+        set $quest_svc       "quest-service:8082";
+        set $project_svc     "project-service:8083";
+        set $progression_svc "progression-service:8084";
+        set $stats_svc       "stats-service:8085";
+        set $admin_svc       "admin-service:8086";
+
         location = /_auth/validate {
             internal;
-            proxy_pass              http://auth_svc/api/auth/validate;
+            proxy_pass              http://$auth_svc/api/auth/validate;
             proxy_pass_request_body off;
             proxy_set_header        Content-Length  "";
             proxy_set_header        Host            $host;
@@ -27,7 +27,7 @@ http {
         }
 
         location /api/auth/ {
-            proxy_pass         http://auth_svc;
+            proxy_pass         http://$auth_svc;
             proxy_set_header   Host              $host;
             proxy_set_header   X-Real-IP         $remote_addr;
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -39,7 +39,7 @@ http {
             auth_request_set $x_user_id   $upstream_http_x_user_id;
             auth_request_set $x_user_role $upstream_http_x_user_role;
             rewrite ^/api/users/[^/]+/progression(.*)$ /api/progression$1 break;
-            proxy_pass       http://progression_svc;
+            proxy_pass       http://$progression_svc;
             proxy_set_header X-User-Id   $x_user_id;
             proxy_set_header X-User-Role $x_user_role;
             proxy_set_header Host        $host;
@@ -49,7 +49,7 @@ http {
             auth_request     /_auth/validate;
             auth_request_set $x_user_id   $upstream_http_x_user_id;
             auth_request_set $x_user_role $upstream_http_x_user_role;
-            proxy_pass       http://auth_svc;
+            proxy_pass       http://$auth_svc;
             proxy_set_header X-User-Id   $x_user_id;
             proxy_set_header X-User-Role $x_user_role;
             proxy_set_header Host        $host;
@@ -59,7 +59,7 @@ http {
             auth_request     /_auth/validate;
             auth_request_set $x_user_id   $upstream_http_x_user_id;
             auth_request_set $x_user_role $upstream_http_x_user_role;
-            proxy_pass       http://quest_svc;
+            proxy_pass       http://$quest_svc;
             proxy_set_header X-User-Id   $x_user_id;
             proxy_set_header X-User-Role $x_user_role;
             proxy_set_header Host        $host;
@@ -69,7 +69,7 @@ http {
             auth_request     /_auth/validate;
             auth_request_set $x_user_id   $upstream_http_x_user_id;
             auth_request_set $x_user_role $upstream_http_x_user_role;
-            proxy_pass       http://project_svc;
+            proxy_pass       http://$project_svc;
             proxy_set_header X-User-Id   $x_user_id;
             proxy_set_header X-User-Role $x_user_role;
             proxy_set_header Host        $host;
@@ -79,7 +79,7 @@ http {
             auth_request     /_auth/validate;
             auth_request_set $x_user_id   $upstream_http_x_user_id;
             auth_request_set $x_user_role $upstream_http_x_user_role;
-            proxy_pass       http://stats_svc;
+            proxy_pass       http://$stats_svc;
             proxy_set_header X-User-Id   $x_user_id;
             proxy_set_header X-User-Role $x_user_role;
             proxy_set_header Host        $host;
@@ -89,7 +89,7 @@ http {
             auth_request     /_auth/validate;
             auth_request_set $x_user_id   $upstream_http_x_user_id;
             auth_request_set $x_user_role $upstream_http_x_user_role;
-            proxy_pass       http://admin_svc;
+            proxy_pass       http://$admin_svc;
             proxy_set_header X-User-Id   $x_user_id;
             proxy_set_header X-User-Role $x_user_role;
             proxy_set_header Host        $host;

--- a/services/questify-admin-service/pom.xml
+++ b/services/questify-admin-service/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/AdminServiceApplication.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/AdminServiceApplication.java
@@ -2,8 +2,10 @@ package com.axelfrache.questify.admin;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class AdminServiceApplication {
 
   public static void main(String[] args) {

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/config/CircuitBreakerConfig.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/config/CircuitBreakerConfig.java
@@ -1,0 +1,47 @@
+package com.axelfrache.questify.admin.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CircuitBreakerConfig {
+
+  @Value("${circuit-breaker.sliding-window-size:10}")
+  private int slidingWindowSize;
+
+  @Value("${circuit-breaker.minimum-number-of-calls:5}")
+  private int minimumNumberOfCalls;
+
+  @Value("${circuit-breaker.failure-rate-threshold:50.0}")
+  private float failureRateThreshold;
+
+  @Value("${circuit-breaker.wait-duration-in-open-state-seconds:30}")
+  private int waitDurationInOpenStateSeconds;
+
+  @Value("${circuit-breaker.permitted-calls-in-half-open:3}")
+  private int permittedCallsInHalfOpen;
+
+  @Bean
+  public CircuitBreakerRegistry circuitBreakerRegistry() {
+    var config =
+        io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.custom()
+            .slidingWindowType(SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(slidingWindowSize)
+            .minimumNumberOfCalls(minimumNumberOfCalls)
+            .failureRateThreshold(failureRateThreshold)
+            .waitDurationInOpenState(Duration.ofSeconds(waitDurationInOpenStateSeconds))
+            .permittedNumberOfCallsInHalfOpenState(permittedCallsInHalfOpen)
+            .build();
+    return CircuitBreakerRegistry.of(config);
+  }
+
+  @Bean
+  public CircuitBreaker rabbitMqCircuitBreaker(CircuitBreakerRegistry registry) {
+    return registry.circuitBreaker("rabbitmq");
+  }
+}

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/config/CircuitBreakerEndpoint.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/config/CircuitBreakerEndpoint.java
@@ -1,0 +1,28 @@
+package com.axelfrache.questify.admin.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+@Component
+@Endpoint(id = "circuitbreaker")
+@RequiredArgsConstructor
+public class CircuitBreakerEndpoint {
+
+  private final CircuitBreaker rabbitMqCircuitBreaker;
+
+  @ReadOperation
+  public Map<String, Object> circuitBreaker() {
+    var metrics = rabbitMqCircuitBreaker.getMetrics();
+    return Map.of(
+        "name", "rabbitmq",
+        "state", rabbitMqCircuitBreaker.getState().name(),
+        "failureRate", metrics.getFailureRate() + "%",
+        "bufferedCalls", metrics.getNumberOfBufferedCalls(),
+        "failedCalls", metrics.getNumberOfFailedCalls(),
+        "successfulCalls", metrics.getNumberOfSuccessfulCalls());
+  }
+}

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/config/JacksonConfig.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/config/JacksonConfig.java
@@ -1,25 +1,14 @@
-package com.axelfrache.questify.auth.config;
+package com.axelfrache.questify.admin.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "questify.ratelimit")
-@Getter
-@Setter
-public class RateLimitConfig {
-
-  private int loginIpPerMinute = 10;
-  private int loginEmailPerMinute = 5;
-  private int registerIpPerMinute = 3;
-  private int refreshIpPerMinute = 30;
+public class JacksonConfig {
 
   @Bean
   @ConditionalOnMissingBean

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/config/RabbitMQConfig.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/config/RabbitMQConfig.java
@@ -1,6 +1,7 @@
 package com.axelfrache.questify.admin.config;
 
 import com.axelfrache.questify.admin.messaging.QueueConstants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Slf4j
 public class RabbitMQConfig {
 
   @Bean
@@ -55,6 +57,21 @@ public class RabbitMQConfig {
       ConnectionFactory connectionFactory, MessageConverter messageConverter) {
     var template = new RabbitTemplate(connectionFactory);
     template.setMessageConverter(messageConverter);
+    template.setMandatory(true);
+    template.setReturnsCallback(
+        returned ->
+            log.warn(
+                "Message returned — exchange={} routingKey={} replyCode={} replyText={}",
+                returned.getExchange(),
+                returned.getRoutingKey(),
+                returned.getReplyCode(),
+                returned.getReplyText()));
+    template.setConfirmCallback(
+        (correlationData, ack, cause) -> {
+          if (!ack) {
+            log.warn("Message nacked — correlationData={} cause={}", correlationData, cause);
+          }
+        });
     return template;
   }
 }

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/messaging/AdminEventPublisher.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/messaging/AdminEventPublisher.java
@@ -1,9 +1,12 @@
 package com.axelfrache.questify.admin.messaging;
 
+import com.axelfrache.questify.admin.model.OutboxEvent;
+import com.axelfrache.questify.admin.repository.OutboxEventRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,45 +14,45 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AdminEventPublisher {
 
-  private final RabbitTemplate rabbitTemplate;
+  private final OutboxEventRepository outboxEventRepository;
+  private final ObjectMapper objectMapper;
 
   public void publishUserDeleted(UUID userId) {
-    try {
-      rabbitTemplate.convertAndSend(
-          QueueConstants.EXCHANGE,
-          QueueConstants.ADMIN_USER_DELETED_ROUTING_KEY,
-          new AdminUserDeletedEvent(userId));
-      log.info("Published AdminUserDeletedEvent for userId={}", userId);
-    } catch (Exception e) {
-      log.warn("Failed to publish AdminUserDeletedEvent for userId={}: {}", userId, e.getMessage());
-    }
+    publish(
+        QueueConstants.ADMIN_USER_DELETED_ROUTING_KEY,
+        new AdminUserDeletedEvent(userId),
+        "AdminUserDeletedEvent",
+        "userId=" + userId);
   }
 
   public void publishRoleChanged(UUID userId, String newRole) {
-    try {
-      rabbitTemplate.convertAndSend(
-          QueueConstants.EXCHANGE,
-          QueueConstants.ADMIN_USER_ROLE_CHANGED_ROUTING_KEY,
-          new AdminUserRoleChangedEvent(userId, newRole));
-      log.debug("Published AdminUserRoleChangedEvent: userId={} role={}", userId, newRole);
-    } catch (Exception e) {
-      log.warn(
-          "Failed to publish AdminUserRoleChangedEvent for userId={}: {}", userId, e.getMessage());
-    }
+    publish(
+        QueueConstants.ADMIN_USER_ROLE_CHANGED_ROUTING_KEY,
+        new AdminUserRoleChangedEvent(userId, newRole),
+        "AdminUserRoleChangedEvent",
+        "userId=" + userId + " role=" + newRole);
   }
 
   public void publishStatusChanged(UUID userId, boolean enabled) {
+    publish(
+        QueueConstants.ADMIN_USER_STATUS_CHANGED_ROUTING_KEY,
+        new AdminUserStatusChangedEvent(userId, enabled),
+        "AdminUserStatusChangedEvent",
+        "userId=" + userId + " enabled=" + enabled);
+  }
+
+  private void publish(String routingKey, Object payload, String eventName, String context) {
     try {
-      rabbitTemplate.convertAndSend(
-          QueueConstants.EXCHANGE,
-          QueueConstants.ADMIN_USER_STATUS_CHANGED_ROUTING_KEY,
-          new AdminUserStatusChangedEvent(userId, enabled));
-      log.debug("Published AdminUserStatusChangedEvent: userId={} enabled={}", userId, enabled);
-    } catch (Exception e) {
-      log.warn(
-          "Failed to publish AdminUserStatusChangedEvent for userId={}: {}",
-          userId,
-          e.getMessage());
+      var outboxEvent =
+          OutboxEvent.builder()
+              .routingKey(routingKey)
+              .payload(objectMapper.writeValueAsString(payload))
+              .typeId(payload.getClass().getName())
+              .build();
+      outboxEventRepository.save(outboxEvent);
+      log.debug("Queued {} to outbox: {}", eventName, context);
+    } catch (JsonProcessingException ex) {
+      throw new RuntimeException("Failed to serialize " + eventName, ex);
     }
   }
 }

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/messaging/OutboxProcessor.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/messaging/OutboxProcessor.java
@@ -1,0 +1,113 @@
+package com.axelfrache.questify.admin.messaging;
+
+import com.axelfrache.questify.admin.model.OutboxEvent;
+import com.axelfrache.questify.admin.model.OutboxStatus;
+import com.axelfrache.questify.admin.repository.OutboxEventRepository;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OutboxProcessor {
+
+  private final OutboxEventRepository outboxEventRepository;
+  private final RabbitTemplate rabbitTemplate;
+  private final CircuitBreaker rabbitMqCircuitBreaker;
+
+  @Value("${outbox.processor.max-attempts:10}")
+  private int maxAttempts;
+
+  @Value("${outbox.publisher-confirm-timeout-ms:5000}")
+  private long publisherConfirmTimeoutMs;
+
+  @Scheduled(fixedDelayString = "${outbox.processor.fixed-delay-ms:5000}")
+  @Transactional
+  public void process() {
+    var pending = outboxEventRepository.findPendingBatchForUpdate();
+    if (pending.isEmpty()) return;
+
+    for (OutboxEvent event : pending) {
+      try {
+        rabbitMqCircuitBreaker.executeCallable(
+            () -> {
+              send(event);
+              return null;
+            });
+        event.setStatus(OutboxStatus.SENT);
+        event.setProcessedAt(Instant.now());
+        event.setNextAttemptAt(null);
+        event.setLastError(null);
+        log.debug("Outbox event sent: id={} routingKey={}", event.getId(), event.getRoutingKey());
+      } catch (CallNotPermittedException ex) {
+        log.warn("Circuit OPEN — outbox processing paused");
+        break;
+      } catch (Exception ex) {
+        scheduleRetry(event, ex);
+        log.warn("Failed to send outbox event: id={} — {}", event.getId(), errorMessage(ex));
+      }
+    }
+  }
+
+  private void send(OutboxEvent event) throws Exception {
+    var message =
+        MessageBuilder.withBody(event.getPayload().getBytes(StandardCharsets.UTF_8))
+            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+            .setHeader("__TypeId__", event.getTypeId())
+            .build();
+    var correlationData = new CorrelationData(event.getId().toString());
+    rabbitTemplate.send(QueueConstants.EXCHANGE, event.getRoutingKey(), message, correlationData);
+
+    var confirm = correlationData.getFuture().get(publisherConfirmTimeoutMs, TimeUnit.MILLISECONDS);
+    if (!confirm.isAck()) {
+      throw new IllegalStateException("RabbitMQ publisher confirm nack: " + confirm.getReason());
+    }
+    var returned = correlationData.getReturned();
+    if (returned != null) {
+      throw new IllegalStateException("RabbitMQ returned message: " + returned.getReplyText());
+    }
+  }
+
+  private void scheduleRetry(OutboxEvent event, Exception ex) {
+    var attempts = event.getAttempts() + 1;
+    event.setAttempts(attempts);
+    event.setLastError(truncate(errorMessage(ex)));
+
+    if (attempts >= maxAttempts) {
+      event.setStatus(OutboxStatus.DEAD);
+      event.setProcessedAt(Instant.now());
+      return;
+    }
+
+    event.setStatus(OutboxStatus.PENDING);
+    event.setNextAttemptAt(Instant.now().plus(backoff(attempts)));
+  }
+
+  private Duration backoff(int attempts) {
+    return Duration.ofSeconds(Math.min(300, 5L * attempts));
+  }
+
+  private String truncate(String value) {
+    if (value == null || value.length() <= 1000) return value;
+    return value.substring(0, 1000);
+  }
+
+  private String errorMessage(Exception ex) {
+    var message = ex.getMessage();
+    return message == null || message.isBlank() ? ex.toString() : message;
+  }
+}

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/model/OutboxEvent.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/model/OutboxEvent.java
@@ -1,0 +1,65 @@
+package com.axelfrache.questify.admin.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(schema = "admin", name = "outbox_events")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OutboxEvent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false)
+  private String routingKey;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String payload;
+
+  @Column(nullable = false)
+  private String typeId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  @Builder.Default
+  private OutboxStatus status = OutboxStatus.PENDING;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+
+  private Instant processedAt;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private int attempts = 0;
+
+  private Instant nextAttemptAt;
+
+  @Column(columnDefinition = "text")
+  private String lastError;
+
+  @PrePersist
+  void prePersist() {
+    if (createdAt == null) createdAt = Instant.now();
+  }
+}

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/model/OutboxStatus.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/model/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.axelfrache.questify.admin.model;
+
+public enum OutboxStatus {
+  PENDING,
+  SENT,
+  DEAD
+}

--- a/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/repository/OutboxEventRepository.java
+++ b/services/questify-admin-service/src/main/java/com/axelfrache/questify/admin/repository/OutboxEventRepository.java
@@ -1,0 +1,24 @@
+package com.axelfrache.questify.admin.repository;
+
+import com.axelfrache.questify.admin.model.OutboxEvent;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+  @Query(
+      value =
+          """
+          SELECT *
+          FROM admin.outbox_events
+          WHERE status = 'PENDING'
+            AND (next_attempt_at IS NULL OR next_attempt_at <= now())
+          ORDER BY created_at
+          LIMIT 50
+          FOR UPDATE SKIP LOCKED
+          """,
+      nativeQuery = true)
+  List<OutboxEvent> findPendingBatchForUpdate();
+}

--- a/services/questify-admin-service/src/main/resources/application.properties
+++ b/services/questify-admin-service/src/main/resources/application.properties
@@ -9,13 +9,30 @@ spring.jpa.properties.hibernate.default_schema=admin
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=false
 
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:sql/schema.sql
+
 spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
 spring.rabbitmq.port=${RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${RABBITMQ_USERNAME:guest}
 spring.rabbitmq.password=${RABBITMQ_PASSWORD:guest}
+spring.rabbitmq.connection-timeout=3000
+spring.rabbitmq.publisher-confirm-type=correlated
+spring.rabbitmq.publisher-returns=true
 
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
-management.endpoints.web.exposure.include=health,prometheus
+circuit-breaker.sliding-window-size=10
+circuit-breaker.minimum-number-of-calls=5
+circuit-breaker.failure-rate-threshold=50.0
+circuit-breaker.wait-duration-in-open-state-seconds=30
+circuit-breaker.permitted-calls-in-half-open=3
+
+outbox.processor.fixed-delay-ms=5000
+outbox.processor.max-attempts=10
+outbox.publisher-confirm-timeout-ms=5000
+
+management.health.rabbit.enabled=false
+management.endpoints.web.exposure.include=health,prometheus,circuitbreaker
 management.endpoint.health.show-details=when_authorized
 management.metrics.tags.application=${spring.application.name}

--- a/services/questify-admin-service/src/main/resources/sql/schema.sql
+++ b/services/questify-admin-service/src/main/resources/sql/schema.sql
@@ -1,0 +1,27 @@
+CREATE SCHEMA IF NOT EXISTS admin;
+
+CREATE TABLE IF NOT EXISTS admin.outbox_events (
+    id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    routing_key     VARCHAR(255) NOT NULL,
+    payload         TEXT         NOT NULL,
+    type_id         VARCHAR(512) NOT NULL,
+    status          VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    processed_at    TIMESTAMPTZ,
+    attempts        INTEGER      NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ,
+    last_error      TEXT
+);
+
+ALTER TABLE admin.outbox_events ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE admin.outbox_events ADD COLUMN IF NOT EXISTS next_attempt_at TIMESTAMPTZ;
+ALTER TABLE admin.outbox_events ADD COLUMN IF NOT EXISTS last_error TEXT;
+
+UPDATE admin.outbox_events
+SET status = 'PENDING',
+    next_attempt_at = now()
+WHERE status = 'FAILED';
+
+CREATE INDEX IF NOT EXISTS idx_admin_outbox_pending
+    ON admin.outbox_events (next_attempt_at, created_at)
+    WHERE status = 'PENDING';

--- a/services/questify-auth-service/pom.xml
+++ b/services/questify-auth-service/pom.xml
@@ -77,6 +77,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/AuthServiceApplication.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/AuthServiceApplication.java
@@ -2,8 +2,10 @@ package com.axelfrache.questify.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class AuthServiceApplication {
 
   public static void main(String[] args) {

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/config/CircuitBreakerConfig.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/config/CircuitBreakerConfig.java
@@ -1,0 +1,47 @@
+package com.axelfrache.questify.auth.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CircuitBreakerConfig {
+
+  @Value("${circuit-breaker.sliding-window-size:10}")
+  private int slidingWindowSize;
+
+  @Value("${circuit-breaker.minimum-number-of-calls:5}")
+  private int minimumNumberOfCalls;
+
+  @Value("${circuit-breaker.failure-rate-threshold:50.0}")
+  private float failureRateThreshold;
+
+  @Value("${circuit-breaker.wait-duration-in-open-state-seconds:30}")
+  private int waitDurationInOpenStateSeconds;
+
+  @Value("${circuit-breaker.permitted-calls-in-half-open:3}")
+  private int permittedCallsInHalfOpen;
+
+  @Bean
+  public CircuitBreakerRegistry circuitBreakerRegistry() {
+    var config =
+        io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.custom()
+            .slidingWindowType(SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(slidingWindowSize)
+            .minimumNumberOfCalls(minimumNumberOfCalls)
+            .failureRateThreshold(failureRateThreshold)
+            .waitDurationInOpenState(Duration.ofSeconds(waitDurationInOpenStateSeconds))
+            .permittedNumberOfCallsInHalfOpenState(permittedCallsInHalfOpen)
+            .build();
+    return CircuitBreakerRegistry.of(config);
+  }
+
+  @Bean
+  public CircuitBreaker rabbitMqCircuitBreaker(CircuitBreakerRegistry registry) {
+    return registry.circuitBreaker("rabbitmq");
+  }
+}

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/config/CircuitBreakerEndpoint.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/config/CircuitBreakerEndpoint.java
@@ -1,0 +1,28 @@
+package com.axelfrache.questify.auth.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+@Component
+@Endpoint(id = "circuitbreaker")
+@RequiredArgsConstructor
+public class CircuitBreakerEndpoint {
+
+  private final CircuitBreaker rabbitMqCircuitBreaker;
+
+  @ReadOperation
+  public Map<String, Object> circuitBreaker() {
+    var metrics = rabbitMqCircuitBreaker.getMetrics();
+    return Map.of(
+        "name", "rabbitmq",
+        "state", rabbitMqCircuitBreaker.getState().name(),
+        "failureRate", metrics.getFailureRate() + "%",
+        "bufferedCalls", metrics.getNumberOfBufferedCalls(),
+        "failedCalls", metrics.getNumberOfFailedCalls(),
+        "successfulCalls", metrics.getNumberOfSuccessfulCalls());
+  }
+}

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/config/RabbitMQConfig.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/config/RabbitMQConfig.java
@@ -1,6 +1,7 @@
 package com.axelfrache.questify.auth.config;
 
 import com.axelfrache.questify.auth.messaging.QueueConstants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Slf4j
 public class RabbitMQConfig {
 
   @Bean
@@ -65,6 +67,21 @@ public class RabbitMQConfig {
   public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
     var template = new RabbitTemplate(connectionFactory);
     template.setMessageConverter(messageConverter());
+    template.setMandatory(true);
+    template.setReturnsCallback(
+        returned ->
+            log.warn(
+                "Message returned — exchange={} routingKey={} replyCode={} replyText={}",
+                returned.getExchange(),
+                returned.getRoutingKey(),
+                returned.getReplyCode(),
+                returned.getReplyText()));
+    template.setConfirmCallback(
+        (correlationData, ack, cause) -> {
+          if (!ack) {
+            log.warn("Message nacked — correlationData={} cause={}", correlationData, cause);
+          }
+        });
     return template;
   }
 }

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/messaging/OutboxProcessor.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/messaging/OutboxProcessor.java
@@ -1,0 +1,114 @@
+package com.axelfrache.questify.auth.messaging;
+
+import com.axelfrache.questify.auth.model.OutboxEvent;
+import com.axelfrache.questify.auth.model.OutboxStatus;
+import com.axelfrache.questify.auth.repository.OutboxEventRepository;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OutboxProcessor {
+
+  private final OutboxEventRepository outboxEventRepository;
+  private final RabbitTemplate rabbitTemplate;
+  private final CircuitBreaker rabbitMqCircuitBreaker;
+
+  @Value("${outbox.processor.max-attempts:10}")
+  private int maxAttempts;
+
+  @Value("${outbox.publisher-confirm-timeout-ms:5000}")
+  private long publisherConfirmTimeoutMs;
+
+  @Scheduled(fixedDelayString = "${outbox.processor.fixed-delay-ms:5000}")
+  @Transactional
+  public void process() {
+    var pending = outboxEventRepository.findPendingBatchForUpdate();
+    if (pending.isEmpty()) return;
+
+    for (OutboxEvent event : pending) {
+      try {
+        rabbitMqCircuitBreaker.executeCallable(
+            () -> {
+              send(event);
+              return null;
+            });
+        event.setStatus(OutboxStatus.SENT);
+        event.setProcessedAt(Instant.now());
+        event.setNextAttemptAt(null);
+        event.setLastError(null);
+        log.debug("Outbox event sent: id={} routingKey={}", event.getId(), event.getRoutingKey());
+      } catch (CallNotPermittedException ex) {
+        log.warn("Circuit OPEN — outbox processing paused");
+        break;
+      } catch (Exception ex) {
+        scheduleRetry(event, ex);
+        log.warn("Failed to send outbox event: id={} — {}", event.getId(), errorMessage(ex));
+      }
+    }
+  }
+
+  private void send(OutboxEvent event) throws Exception {
+    Message message =
+        MessageBuilder.withBody(event.getPayload().getBytes(StandardCharsets.UTF_8))
+            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+            .setHeader("__TypeId__", event.getTypeId())
+            .build();
+    var correlationData = new CorrelationData(event.getId().toString());
+    rabbitTemplate.send(QueueConstants.EXCHANGE, event.getRoutingKey(), message, correlationData);
+
+    var confirm = correlationData.getFuture().get(publisherConfirmTimeoutMs, TimeUnit.MILLISECONDS);
+    if (!confirm.isAck()) {
+      throw new IllegalStateException("RabbitMQ publisher confirm nack: " + confirm.getReason());
+    }
+    var returned = correlationData.getReturned();
+    if (returned != null) {
+      throw new IllegalStateException("RabbitMQ returned message: " + returned.getReplyText());
+    }
+  }
+
+  private void scheduleRetry(OutboxEvent event, Exception ex) {
+    var attempts = event.getAttempts() + 1;
+    event.setAttempts(attempts);
+    event.setLastError(truncate(errorMessage(ex)));
+
+    if (attempts >= maxAttempts) {
+      event.setStatus(OutboxStatus.DEAD);
+      event.setProcessedAt(Instant.now());
+      return;
+    }
+
+    event.setStatus(OutboxStatus.PENDING);
+    event.setNextAttemptAt(Instant.now().plus(backoff(attempts)));
+  }
+
+  private Duration backoff(int attempts) {
+    return Duration.ofSeconds(Math.min(300, 5L * attempts));
+  }
+
+  private String truncate(String value) {
+    if (value == null || value.length() <= 1000) return value;
+    return value.substring(0, 1000);
+  }
+
+  private String errorMessage(Exception ex) {
+    var message = ex.getMessage();
+    return message == null || message.isBlank() ? ex.toString() : message;
+  }
+}

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/messaging/UserEventPublisher.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/messaging/UserEventPublisher.java
@@ -1,9 +1,12 @@
 package com.axelfrache.questify.auth.messaging;
 
+import com.axelfrache.questify.auth.model.OutboxEvent;
+import com.axelfrache.questify.auth.repository.OutboxEventRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,30 +14,30 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class UserEventPublisher {
 
-  private final RabbitTemplate rabbitTemplate;
+  private final OutboxEventRepository outboxEventRepository;
+  private final ObjectMapper objectMapper;
 
   public void publishUserDeleted(UUID userId) {
-    try {
-      rabbitTemplate.convertAndSend(
-          QueueConstants.EXCHANGE,
-          QueueConstants.USER_DELETED_ROUTING_KEY,
-          new UserDeletedEvent(userId));
-      log.info("Published UserDeletedEvent for userId={}", userId);
-    } catch (Exception e) {
-      log.warn("Failed to publish UserDeletedEvent for userId={}: {}", userId, e.getMessage());
-    }
+    queue(
+        QueueConstants.USER_DELETED_ROUTING_KEY, new UserDeletedEvent(userId), "UserDeletedEvent");
   }
 
   public void publishUserRegistered(UserRegisteredEvent event) {
+    queue(QueueConstants.USER_REGISTERED_ROUTING_KEY, event, "UserRegisteredEvent");
+  }
+
+  private void queue(String routingKey, Object payload, String eventName) {
     try {
-      rabbitTemplate.convertAndSend(
-          QueueConstants.EXCHANGE, QueueConstants.USER_REGISTERED_ROUTING_KEY, event);
-      log.debug("Published UserRegisteredEvent for userId={}", event.userId());
-    } catch (Exception e) {
-      log.warn(
-          "Failed to publish UserRegisteredEvent for userId={}: {}",
-          event.userId(),
-          e.getMessage());
+      var outboxEvent =
+          OutboxEvent.builder()
+              .routingKey(routingKey)
+              .payload(objectMapper.writeValueAsString(payload))
+              .typeId(payload.getClass().getName())
+              .build();
+      outboxEventRepository.save(outboxEvent);
+      log.debug("Queued {} to outbox", eventName);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize " + eventName, e);
     }
   }
 }

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/model/OutboxEvent.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/model/OutboxEvent.java
@@ -1,0 +1,65 @@
+package com.axelfrache.questify.auth.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(schema = "auth", name = "outbox_events")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OutboxEvent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false)
+  private String routingKey;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String payload;
+
+  @Column(nullable = false)
+  private String typeId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  @Builder.Default
+  private OutboxStatus status = OutboxStatus.PENDING;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+
+  private Instant processedAt;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private int attempts = 0;
+
+  private Instant nextAttemptAt;
+
+  @Column(columnDefinition = "text")
+  private String lastError;
+
+  @PrePersist
+  void prePersist() {
+    if (createdAt == null) createdAt = Instant.now();
+  }
+}

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/model/OutboxStatus.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/model/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.axelfrache.questify.auth.model;
+
+public enum OutboxStatus {
+  PENDING,
+  SENT,
+  DEAD
+}

--- a/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/repository/OutboxEventRepository.java
+++ b/services/questify-auth-service/src/main/java/com/axelfrache/questify/auth/repository/OutboxEventRepository.java
@@ -1,0 +1,24 @@
+package com.axelfrache.questify.auth.repository;
+
+import com.axelfrache.questify.auth.model.OutboxEvent;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+  @Query(
+      value =
+          """
+          SELECT *
+          FROM auth.outbox_events
+          WHERE status = 'PENDING'
+            AND (next_attempt_at IS NULL OR next_attempt_at <= now())
+          ORDER BY created_at
+          LIMIT 50
+          FOR UPDATE SKIP LOCKED
+          """,
+      nativeQuery = true)
+  List<OutboxEvent> findPendingBatchForUpdate();
+}

--- a/services/questify-auth-service/src/main/resources/application.properties
+++ b/services/questify-auth-service/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=questify-auth-service
 server.port=8081
 
-spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:h2:mem:auth}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME:sa}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
-spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER:org.h2.Driver}
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/questify}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:questify}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:questify}
+spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER:org.postgresql.Driver}
 spring.jpa.hibernate.ddl-auto=${SPRING_JPA_DDL_AUTO:update}
 spring.jpa.properties.hibernate.default_schema=auth
 spring.jpa.open-in-view=false
@@ -14,6 +14,9 @@ spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
 spring.rabbitmq.port=${RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${RABBITMQ_USERNAME:questify}
 spring.rabbitmq.password=${RABBITMQ_PASSWORD:questify}
+spring.rabbitmq.connection-timeout=3000
+spring.rabbitmq.publisher-confirm-type=correlated
+spring.rabbitmq.publisher-returns=true
 
 spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:sql/schema.sql
@@ -41,6 +44,17 @@ questify.ratelimit.login-email-per-minute=${LOGIN_RATE_LIMIT_EMAIL:5}
 questify.ratelimit.register-ip-per-minute=${REGISTER_RATE_LIMIT_IP:3}
 questify.ratelimit.refresh-ip-per-minute=${REFRESH_RATE_LIMIT_IP:30}
 
-management.endpoints.web.exposure.include=health,prometheus
+circuit-breaker.sliding-window-size=10
+circuit-breaker.minimum-number-of-calls=5
+circuit-breaker.failure-rate-threshold=50.0
+circuit-breaker.wait-duration-in-open-state-seconds=30
+circuit-breaker.permitted-calls-in-half-open=3
+
+outbox.processor.fixed-delay-ms=5000
+outbox.processor.max-attempts=10
+outbox.publisher-confirm-timeout-ms=5000
+
+management.health.rabbit.enabled=false
+management.endpoints.web.exposure.include=health,prometheus,circuitbreaker
 management.endpoint.health.show-details=when_authorized
 management.metrics.tags.application=${spring.application.name}

--- a/services/questify-auth-service/src/main/resources/sql/schema.sql
+++ b/services/questify-auth-service/src/main/resources/sql/schema.sql
@@ -1,1 +1,27 @@
 CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE TABLE IF NOT EXISTS auth.outbox_events (
+    id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    routing_key  VARCHAR(255) NOT NULL,
+    payload      TEXT         NOT NULL,
+    type_id      VARCHAR(512) NOT NULL,
+    status       VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    processed_at TIMESTAMPTZ,
+    attempts     INTEGER      NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ,
+    last_error   TEXT
+);
+
+ALTER TABLE auth.outbox_events ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE auth.outbox_events ADD COLUMN IF NOT EXISTS next_attempt_at TIMESTAMPTZ;
+ALTER TABLE auth.outbox_events ADD COLUMN IF NOT EXISTS last_error TEXT;
+
+UPDATE auth.outbox_events
+SET status = 'PENDING',
+    next_attempt_at = now()
+WHERE status = 'FAILED';
+
+CREATE INDEX IF NOT EXISTS idx_auth_outbox_pending_retry
+    ON auth.outbox_events (next_attempt_at, created_at)
+    WHERE status = 'PENDING';

--- a/services/questify-progression-service/src/main/resources/application.properties
+++ b/services/questify-progression-service/src/main/resources/application.properties
@@ -24,6 +24,7 @@ questify.level.multiplier=1.0
 
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
+management.health.rabbit.enabled=false
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=when_authorized
 management.metrics.tags.application=${spring.application.name}

--- a/services/questify-project-service/pom.xml
+++ b/services/questify-project-service/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/ProjectServiceApplication.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/ProjectServiceApplication.java
@@ -2,8 +2,10 @@ package com.axelfrache.questify.project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ProjectServiceApplication {
 
   public static void main(String[] args) {

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/config/CircuitBreakerConfig.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/config/CircuitBreakerConfig.java
@@ -1,0 +1,47 @@
+package com.axelfrache.questify.project.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CircuitBreakerConfig {
+
+  @Value("${circuit-breaker.sliding-window-size:10}")
+  private int slidingWindowSize;
+
+  @Value("${circuit-breaker.minimum-number-of-calls:5}")
+  private int minimumNumberOfCalls;
+
+  @Value("${circuit-breaker.failure-rate-threshold:50.0}")
+  private float failureRateThreshold;
+
+  @Value("${circuit-breaker.wait-duration-in-open-state-seconds:30}")
+  private int waitDurationInOpenStateSeconds;
+
+  @Value("${circuit-breaker.permitted-calls-in-half-open:3}")
+  private int permittedCallsInHalfOpen;
+
+  @Bean
+  public CircuitBreakerRegistry circuitBreakerRegistry() {
+    var config =
+        io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.custom()
+            .slidingWindowType(SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(slidingWindowSize)
+            .minimumNumberOfCalls(minimumNumberOfCalls)
+            .failureRateThreshold(failureRateThreshold)
+            .waitDurationInOpenState(Duration.ofSeconds(waitDurationInOpenStateSeconds))
+            .permittedNumberOfCallsInHalfOpenState(permittedCallsInHalfOpen)
+            .build();
+    return CircuitBreakerRegistry.of(config);
+  }
+
+  @Bean
+  public CircuitBreaker rabbitMqCircuitBreaker(CircuitBreakerRegistry registry) {
+    return registry.circuitBreaker("rabbitmq");
+  }
+}

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/config/CircuitBreakerEndpoint.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/config/CircuitBreakerEndpoint.java
@@ -1,0 +1,28 @@
+package com.axelfrache.questify.project.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+@Component
+@Endpoint(id = "circuitbreaker")
+@RequiredArgsConstructor
+public class CircuitBreakerEndpoint {
+
+  private final CircuitBreaker rabbitMqCircuitBreaker;
+
+  @ReadOperation
+  public Map<String, Object> circuitBreaker() {
+    var metrics = rabbitMqCircuitBreaker.getMetrics();
+    return Map.of(
+        "name", "rabbitmq",
+        "state", rabbitMqCircuitBreaker.getState().name(),
+        "failureRate", metrics.getFailureRate() + "%",
+        "bufferedCalls", metrics.getNumberOfBufferedCalls(),
+        "failedCalls", metrics.getNumberOfFailedCalls(),
+        "successfulCalls", metrics.getNumberOfSuccessfulCalls());
+  }
+}

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/config/JacksonConfig.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/config/JacksonConfig.java
@@ -1,25 +1,14 @@
-package com.axelfrache.questify.auth.config;
+package com.axelfrache.questify.project.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "questify.ratelimit")
-@Getter
-@Setter
-public class RateLimitConfig {
-
-  private int loginIpPerMinute = 10;
-  private int loginEmailPerMinute = 5;
-  private int registerIpPerMinute = 3;
-  private int refreshIpPerMinute = 30;
+public class JacksonConfig {
 
   @Bean
   @ConditionalOnMissingBean

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/config/RabbitMQConfig.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/config/RabbitMQConfig.java
@@ -1,6 +1,7 @@
 package com.axelfrache.questify.project.config;
 
 import com.axelfrache.questify.project.messaging.QueueConstants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Slf4j
 public class RabbitMQConfig {
 
   @Bean
@@ -40,6 +42,21 @@ public class RabbitMQConfig {
   public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
     var template = new RabbitTemplate(connectionFactory);
     template.setMessageConverter(messageConverter());
+    template.setMandatory(true);
+    template.setReturnsCallback(
+        returned ->
+            log.warn(
+                "Message returned — exchange={} routingKey={} replyCode={} replyText={}",
+                returned.getExchange(),
+                returned.getRoutingKey(),
+                returned.getReplyCode(),
+                returned.getReplyText()));
+    template.setConfirmCallback(
+        (correlationData, ack, cause) -> {
+          if (!ack) {
+            log.warn("Message nacked — correlationData={} cause={}", correlationData, cause);
+          }
+        });
     return template;
   }
 }

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/messaging/OutboxProcessor.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/messaging/OutboxProcessor.java
@@ -1,0 +1,113 @@
+package com.axelfrache.questify.project.messaging;
+
+import com.axelfrache.questify.project.model.OutboxEvent;
+import com.axelfrache.questify.project.model.OutboxStatus;
+import com.axelfrache.questify.project.repository.OutboxEventRepository;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OutboxProcessor {
+
+  private final OutboxEventRepository outboxEventRepository;
+  private final RabbitTemplate rabbitTemplate;
+  private final CircuitBreaker rabbitMqCircuitBreaker;
+
+  @Value("${outbox.processor.max-attempts:10}")
+  private int maxAttempts;
+
+  @Value("${outbox.publisher-confirm-timeout-ms:5000}")
+  private long publisherConfirmTimeoutMs;
+
+  @Scheduled(fixedDelayString = "${outbox.processor.fixed-delay-ms:5000}")
+  @Transactional
+  public void process() {
+    var pending = outboxEventRepository.findPendingBatchForUpdate();
+    if (pending.isEmpty()) return;
+
+    for (OutboxEvent event : pending) {
+      try {
+        rabbitMqCircuitBreaker.executeCallable(
+            () -> {
+              send(event);
+              return null;
+            });
+        event.setStatus(OutboxStatus.SENT);
+        event.setProcessedAt(Instant.now());
+        event.setNextAttemptAt(null);
+        event.setLastError(null);
+        log.debug("Outbox event sent: id={} routingKey={}", event.getId(), event.getRoutingKey());
+      } catch (CallNotPermittedException ex) {
+        log.warn("Circuit OPEN — outbox processing paused");
+        break;
+      } catch (Exception ex) {
+        scheduleRetry(event, ex);
+        log.warn("Failed to send outbox event: id={} — {}", event.getId(), errorMessage(ex));
+      }
+    }
+  }
+
+  private void send(OutboxEvent event) throws Exception {
+    var message =
+        MessageBuilder.withBody(event.getPayload().getBytes(StandardCharsets.UTF_8))
+            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+            .setHeader("__TypeId__", event.getTypeId())
+            .build();
+    var correlationData = new CorrelationData(event.getId().toString());
+    rabbitTemplate.send(QueueConstants.EXCHANGE, event.getRoutingKey(), message, correlationData);
+
+    var confirm = correlationData.getFuture().get(publisherConfirmTimeoutMs, TimeUnit.MILLISECONDS);
+    if (!confirm.isAck()) {
+      throw new IllegalStateException("RabbitMQ publisher confirm nack: " + confirm.getReason());
+    }
+    var returned = correlationData.getReturned();
+    if (returned != null) {
+      throw new IllegalStateException("RabbitMQ returned message: " + returned.getReplyText());
+    }
+  }
+
+  private void scheduleRetry(OutboxEvent event, Exception ex) {
+    var attempts = event.getAttempts() + 1;
+    event.setAttempts(attempts);
+    event.setLastError(truncate(errorMessage(ex)));
+
+    if (attempts >= maxAttempts) {
+      event.setStatus(OutboxStatus.DEAD);
+      event.setProcessedAt(Instant.now());
+      return;
+    }
+
+    event.setStatus(OutboxStatus.PENDING);
+    event.setNextAttemptAt(Instant.now().plus(backoff(attempts)));
+  }
+
+  private Duration backoff(int attempts) {
+    return Duration.ofSeconds(Math.min(300, 5L * attempts));
+  }
+
+  private String truncate(String value) {
+    if (value == null || value.length() <= 1000) return value;
+    return value.substring(0, 1000);
+  }
+
+  private String errorMessage(Exception ex) {
+    var message = ex.getMessage();
+    return message == null || message.isBlank() ? ex.toString() : message;
+  }
+}

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/messaging/ProjectEventPublisher.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/messaging/ProjectEventPublisher.java
@@ -1,9 +1,12 @@
 package com.axelfrache.questify.project.messaging;
 
+import com.axelfrache.questify.project.model.OutboxEvent;
+import com.axelfrache.questify.project.repository.OutboxEventRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,19 +14,22 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class ProjectEventPublisher {
 
-  private final RabbitTemplate rabbitTemplate;
+  private final OutboxEventRepository outboxEventRepository;
+  private final ObjectMapper objectMapper;
 
   public void publishProjectDeleted(UUID projectId) {
+    var event = new ProjectDeletedEvent(projectId);
     try {
-      var event = new ProjectDeletedEvent(projectId);
-      rabbitTemplate.convertAndSend(
-          QueueConstants.EXCHANGE, QueueConstants.PROJECT_DELETED_ROUTING_KEY, event);
-      log.debug("Published ProjectDeletedEvent: projectId={}", projectId);
-    } catch (Exception e) {
-      log.warn(
-          "Failed to publish ProjectDeletedEvent for projectId={} — quest-service will not unlink quests: {}",
-          projectId,
-          e.getMessage());
+      var outboxEvent =
+          OutboxEvent.builder()
+              .routingKey(QueueConstants.PROJECT_DELETED_ROUTING_KEY)
+              .payload(objectMapper.writeValueAsString(event))
+              .typeId(ProjectDeletedEvent.class.getName())
+              .build();
+      outboxEventRepository.save(outboxEvent);
+      log.debug("Queued ProjectDeletedEvent to outbox: projectId={}", projectId);
+    } catch (JsonProcessingException ex) {
+      throw new RuntimeException("Failed to serialize ProjectDeletedEvent", ex);
     }
   }
 }

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/model/OutboxEvent.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/model/OutboxEvent.java
@@ -1,0 +1,65 @@
+package com.axelfrache.questify.project.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(schema = "projects", name = "outbox_events")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OutboxEvent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false)
+  private String routingKey;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String payload;
+
+  @Column(nullable = false)
+  private String typeId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  @Builder.Default
+  private OutboxStatus status = OutboxStatus.PENDING;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+
+  private Instant processedAt;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private int attempts = 0;
+
+  private Instant nextAttemptAt;
+
+  @Column(columnDefinition = "text")
+  private String lastError;
+
+  @PrePersist
+  void prePersist() {
+    if (createdAt == null) createdAt = Instant.now();
+  }
+}

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/model/OutboxStatus.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/model/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.axelfrache.questify.project.model;
+
+public enum OutboxStatus {
+  PENDING,
+  SENT,
+  DEAD
+}

--- a/services/questify-project-service/src/main/java/com/axelfrache/questify/project/repository/OutboxEventRepository.java
+++ b/services/questify-project-service/src/main/java/com/axelfrache/questify/project/repository/OutboxEventRepository.java
@@ -1,0 +1,24 @@
+package com.axelfrache.questify.project.repository;
+
+import com.axelfrache.questify.project.model.OutboxEvent;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+  @Query(
+      value =
+          """
+          SELECT *
+          FROM projects.outbox_events
+          WHERE status = 'PENDING'
+            AND (next_attempt_at IS NULL OR next_attempt_at <= now())
+          ORDER BY created_at
+          LIMIT 50
+          FOR UPDATE SKIP LOCKED
+          """,
+      nativeQuery = true)
+  List<OutboxEvent> findPendingBatchForUpdate();
+}

--- a/services/questify-project-service/src/main/resources/application.properties
+++ b/services/questify-project-service/src/main/resources/application.properties
@@ -17,9 +17,23 @@ spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
 spring.rabbitmq.port=${RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${RABBITMQ_USERNAME:questify}
 spring.rabbitmq.password=${RABBITMQ_PASSWORD:questify}
+spring.rabbitmq.connection-timeout=3000
+spring.rabbitmq.publisher-confirm-type=correlated
+spring.rabbitmq.publisher-returns=true
 
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
-management.endpoints.web.exposure.include=health,prometheus
+circuit-breaker.sliding-window-size=10
+circuit-breaker.minimum-number-of-calls=5
+circuit-breaker.failure-rate-threshold=50.0
+circuit-breaker.wait-duration-in-open-state-seconds=30
+circuit-breaker.permitted-calls-in-half-open=3
+
+outbox.processor.fixed-delay-ms=5000
+outbox.processor.max-attempts=10
+outbox.publisher-confirm-timeout-ms=5000
+
+management.health.rabbit.enabled=false
+management.endpoints.web.exposure.include=health,prometheus,circuitbreaker
 management.endpoint.health.show-details=when_authorized
 management.metrics.tags.application=${spring.application.name}

--- a/services/questify-project-service/src/main/resources/sql/schema.sql
+++ b/services/questify-project-service/src/main/resources/sql/schema.sql
@@ -36,3 +36,29 @@ CREATE TABLE IF NOT EXISTS projects.user_project_pins (
 
 CREATE INDEX IF NOT EXISTS idx_user_project_pins_user_id ON projects.user_project_pins(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_project_pins_pinned_at ON projects.user_project_pins(pinned_at);
+
+CREATE TABLE IF NOT EXISTS projects.outbox_events (
+    id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    routing_key     VARCHAR(255) NOT NULL,
+    payload         TEXT         NOT NULL,
+    type_id         VARCHAR(512) NOT NULL,
+    status          VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    processed_at    TIMESTAMPTZ,
+    attempts        INTEGER      NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ,
+    last_error      TEXT
+);
+
+ALTER TABLE projects.outbox_events ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE projects.outbox_events ADD COLUMN IF NOT EXISTS next_attempt_at TIMESTAMPTZ;
+ALTER TABLE projects.outbox_events ADD COLUMN IF NOT EXISTS last_error TEXT;
+
+UPDATE projects.outbox_events
+SET status = 'PENDING',
+    next_attempt_at = now()
+WHERE status = 'FAILED';
+
+CREATE INDEX IF NOT EXISTS idx_projects_outbox_pending
+    ON projects.outbox_events (next_attempt_at, created_at)
+    WHERE status = 'PENDING';

--- a/services/questify-quest-service/pom.xml
+++ b/services/questify-quest-service/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/QuestServiceApplication.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/QuestServiceApplication.java
@@ -2,8 +2,10 @@ package com.axelfrache.questify.quest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class QuestServiceApplication {
 
   public static void main(String[] args) {

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/config/CircuitBreakerConfig.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/config/CircuitBreakerConfig.java
@@ -1,0 +1,47 @@
+package com.axelfrache.questify.quest.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CircuitBreakerConfig {
+
+  @Value("${circuit-breaker.sliding-window-size:10}")
+  private int slidingWindowSize;
+
+  @Value("${circuit-breaker.minimum-number-of-calls:5}")
+  private int minimumNumberOfCalls;
+
+  @Value("${circuit-breaker.failure-rate-threshold:50.0}")
+  private float failureRateThreshold;
+
+  @Value("${circuit-breaker.wait-duration-in-open-state-seconds:30}")
+  private int waitDurationInOpenStateSeconds;
+
+  @Value("${circuit-breaker.permitted-calls-in-half-open:3}")
+  private int permittedCallsInHalfOpen;
+
+  @Bean
+  public CircuitBreakerRegistry circuitBreakerRegistry() {
+    var config =
+        io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.custom()
+            .slidingWindowType(SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(slidingWindowSize)
+            .minimumNumberOfCalls(minimumNumberOfCalls)
+            .failureRateThreshold(failureRateThreshold)
+            .waitDurationInOpenState(Duration.ofSeconds(waitDurationInOpenStateSeconds))
+            .permittedNumberOfCallsInHalfOpenState(permittedCallsInHalfOpen)
+            .build();
+    return CircuitBreakerRegistry.of(config);
+  }
+
+  @Bean
+  public CircuitBreaker rabbitMqCircuitBreaker(CircuitBreakerRegistry registry) {
+    return registry.circuitBreaker("rabbitmq");
+  }
+}

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/config/CircuitBreakerEndpoint.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/config/CircuitBreakerEndpoint.java
@@ -1,0 +1,28 @@
+package com.axelfrache.questify.quest.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+@Component
+@Endpoint(id = "circuitbreaker")
+@RequiredArgsConstructor
+public class CircuitBreakerEndpoint {
+
+  private final CircuitBreaker rabbitMqCircuitBreaker;
+
+  @ReadOperation
+  public Map<String, Object> circuitBreaker() {
+    var metrics = rabbitMqCircuitBreaker.getMetrics();
+    return Map.of(
+        "name", "rabbitmq",
+        "state", rabbitMqCircuitBreaker.getState().name(),
+        "failureRate", metrics.getFailureRate() + "%",
+        "bufferedCalls", metrics.getNumberOfBufferedCalls(),
+        "failedCalls", metrics.getNumberOfFailedCalls(),
+        "successfulCalls", metrics.getNumberOfSuccessfulCalls());
+  }
+}

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/config/JacksonConfig.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/config/JacksonConfig.java
@@ -1,25 +1,14 @@
-package com.axelfrache.questify.auth.config;
+package com.axelfrache.questify.quest.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "questify.ratelimit")
-@Getter
-@Setter
-public class RateLimitConfig {
-
-  private int loginIpPerMinute = 10;
-  private int loginEmailPerMinute = 5;
-  private int registerIpPerMinute = 3;
-  private int refreshIpPerMinute = 30;
+public class JacksonConfig {
 
   @Bean
   @ConditionalOnMissingBean

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/config/RabbitMQConfig.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/config/RabbitMQConfig.java
@@ -1,6 +1,7 @@
 package com.axelfrache.questify.quest.config;
 
 import com.axelfrache.questify.quest.messaging.QueueConstants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Slf4j
 public class RabbitMQConfig {
 
   @Bean
@@ -66,6 +68,21 @@ public class RabbitMQConfig {
   public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
     var template = new RabbitTemplate(connectionFactory);
     template.setMessageConverter(messageConverter());
+    template.setMandatory(true);
+    template.setReturnsCallback(
+        returned ->
+            log.warn(
+                "Message returned — exchange={} routingKey={} replyCode={} replyText={}",
+                returned.getExchange(),
+                returned.getRoutingKey(),
+                returned.getReplyCode(),
+                returned.getReplyText()));
+    template.setConfirmCallback(
+        (correlationData, ack, cause) -> {
+          if (!ack) {
+            log.warn("Message nacked — correlationData={} cause={}", correlationData, cause);
+          }
+        });
     return template;
   }
 }

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/OutboxProcessor.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/OutboxProcessor.java
@@ -1,0 +1,114 @@
+package com.axelfrache.questify.quest.messaging;
+
+import com.axelfrache.questify.quest.model.OutboxEvent;
+import com.axelfrache.questify.quest.model.OutboxStatus;
+import com.axelfrache.questify.quest.repository.OutboxEventRepository;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OutboxProcessor {
+
+  private final OutboxEventRepository outboxEventRepository;
+  private final RabbitTemplate rabbitTemplate;
+  private final CircuitBreaker rabbitMqCircuitBreaker;
+
+  @Value("${outbox.processor.max-attempts:10}")
+  private int maxAttempts;
+
+  @Value("${outbox.publisher-confirm-timeout-ms:5000}")
+  private long publisherConfirmTimeoutMs;
+
+  @Scheduled(fixedDelayString = "${outbox.processor.fixed-delay-ms:5000}")
+  @Transactional
+  public void process() {
+    var pending = outboxEventRepository.findPendingBatchForUpdate();
+    if (pending.isEmpty()) return;
+
+    for (OutboxEvent event : pending) {
+      try {
+        rabbitMqCircuitBreaker.executeCallable(
+            () -> {
+              send(event);
+              return null;
+            });
+        event.setStatus(OutboxStatus.SENT);
+        event.setProcessedAt(Instant.now());
+        event.setNextAttemptAt(null);
+        event.setLastError(null);
+        log.debug("Outbox event sent: id={} routingKey={}", event.getId(), event.getRoutingKey());
+      } catch (CallNotPermittedException ex) {
+        log.warn("Circuit OPEN — outbox processing paused");
+        break;
+      } catch (Exception ex) {
+        scheduleRetry(event, ex);
+        log.warn("Failed to send outbox event: id={} — {}", event.getId(), errorMessage(ex));
+      }
+    }
+  }
+
+  private void send(OutboxEvent event) throws Exception {
+    Message message =
+        MessageBuilder.withBody(event.getPayload().getBytes(StandardCharsets.UTF_8))
+            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+            .setHeader("__TypeId__", event.getTypeId())
+            .build();
+    var correlationData = new CorrelationData(event.getId().toString());
+    rabbitTemplate.send(QueueConstants.EXCHANGE, event.getRoutingKey(), message, correlationData);
+
+    var confirm = correlationData.getFuture().get(publisherConfirmTimeoutMs, TimeUnit.MILLISECONDS);
+    if (!confirm.isAck()) {
+      throw new IllegalStateException("RabbitMQ publisher confirm nack: " + confirm.getReason());
+    }
+    var returned = correlationData.getReturned();
+    if (returned != null) {
+      throw new IllegalStateException("RabbitMQ returned message: " + returned.getReplyText());
+    }
+  }
+
+  private void scheduleRetry(OutboxEvent event, Exception ex) {
+    var attempts = event.getAttempts() + 1;
+    event.setAttempts(attempts);
+    event.setLastError(truncate(errorMessage(ex)));
+
+    if (attempts >= maxAttempts) {
+      event.setStatus(OutboxStatus.DEAD);
+      event.setProcessedAt(Instant.now());
+      return;
+    }
+
+    event.setStatus(OutboxStatus.PENDING);
+    event.setNextAttemptAt(Instant.now().plus(backoff(attempts)));
+  }
+
+  private Duration backoff(int attempts) {
+    return Duration.ofSeconds(Math.min(300, 5L * attempts));
+  }
+
+  private String truncate(String value) {
+    if (value == null || value.length() <= 1000) return value;
+    return value.substring(0, 1000);
+  }
+
+  private String errorMessage(Exception ex) {
+    var message = ex.getMessage();
+    return message == null || message.isBlank() ? ex.toString() : message;
+  }
+}

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QuestEventPublisher.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QuestEventPublisher.java
@@ -1,10 +1,13 @@
 package com.axelfrache.questify.quest.messaging;
 
+import com.axelfrache.questify.quest.model.OutboxEvent;
+import com.axelfrache.questify.quest.repository.OutboxEventRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,7 +15,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class QuestEventPublisher {
 
-  private final RabbitTemplate rabbitTemplate;
+  private final OutboxEventRepository outboxEventRepository;
+  private final ObjectMapper objectMapper;
 
   public void publishQuestCompleted(
       UUID userId,
@@ -23,9 +27,21 @@ public class QuestEventPublisher {
       Instant completedAt) {
     var event =
         new QuestCompletedEvent(userId, questId, questTitle, xpEarned, categoryName, completedAt);
-    rabbitTemplate.convertAndSend(
-        QueueConstants.EXCHANGE, QueueConstants.QUEST_COMPLETED_ROUTING_KEY, event);
-    log.debug(
-        "Published QuestCompletedEvent: userId={} questId={} xp={}", userId, questId, xpEarned);
+    try {
+      var outboxEvent =
+          OutboxEvent.builder()
+              .routingKey(QueueConstants.QUEST_COMPLETED_ROUTING_KEY)
+              .payload(objectMapper.writeValueAsString(event))
+              .typeId(QuestCompletedEvent.class.getName())
+              .build();
+      outboxEventRepository.save(outboxEvent);
+      log.debug(
+          "Queued QuestCompletedEvent to outbox: userId={} questId={} xp={}",
+          userId,
+          questId,
+          xpEarned);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize QuestCompletedEvent", e);
+    }
   }
 }

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/model/OutboxEvent.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/model/OutboxEvent.java
@@ -1,0 +1,65 @@
+package com.axelfrache.questify.quest.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(schema = "quests", name = "outbox_events")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OutboxEvent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false)
+  private String routingKey;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String payload;
+
+  @Column(nullable = false)
+  private String typeId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  @Builder.Default
+  private OutboxStatus status = OutboxStatus.PENDING;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+
+  private Instant processedAt;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private int attempts = 0;
+
+  private Instant nextAttemptAt;
+
+  @Column(columnDefinition = "text")
+  private String lastError;
+
+  @PrePersist
+  void prePersist() {
+    if (createdAt == null) createdAt = Instant.now();
+  }
+}

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/model/OutboxStatus.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/model/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.axelfrache.questify.quest.model;
+
+public enum OutboxStatus {
+  PENDING,
+  SENT,
+  DEAD
+}

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/repository/OutboxEventRepository.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/repository/OutboxEventRepository.java
@@ -1,0 +1,24 @@
+package com.axelfrache.questify.quest.repository;
+
+import com.axelfrache.questify.quest.model.OutboxEvent;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+  @Query(
+      value =
+          """
+          SELECT *
+          FROM quests.outbox_events
+          WHERE status = 'PENDING'
+            AND (next_attempt_at IS NULL OR next_attempt_at <= now())
+          ORDER BY created_at
+          LIMIT 50
+          FOR UPDATE SKIP LOCKED
+          """,
+      nativeQuery = true)
+  List<OutboxEvent> findPendingBatchForUpdate();
+}

--- a/services/questify-quest-service/src/main/resources/application.properties
+++ b/services/questify-quest-service/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=questify-quest-service
 server.port=8082
 
-spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:h2:mem:quests}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME:sa}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
-spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER:org.h2.Driver}
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/questify}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:questify}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:questify}
+spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER:org.postgresql.Driver}
 spring.jpa.hibernate.ddl-auto=${SPRING_JPA_DDL_AUTO:update}
 spring.jpa.properties.hibernate.default_schema=quests
 spring.jpa.open-in-view=false
@@ -14,12 +14,26 @@ spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
 spring.rabbitmq.port=${RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${RABBITMQ_USERNAME:questify}
 spring.rabbitmq.password=${RABBITMQ_PASSWORD:questify}
+spring.rabbitmq.connection-timeout=3000
+spring.rabbitmq.publisher-confirm-type=correlated
+spring.rabbitmq.publisher-returns=true
 
 spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:sql/schema.sql
 
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
-management.endpoints.web.exposure.include=health,prometheus
+circuit-breaker.sliding-window-size=10
+circuit-breaker.minimum-number-of-calls=5
+circuit-breaker.failure-rate-threshold=50.0
+circuit-breaker.wait-duration-in-open-state-seconds=30
+circuit-breaker.permitted-calls-in-half-open=3
+
+outbox.processor.fixed-delay-ms=5000
+outbox.processor.max-attempts=10
+outbox.publisher-confirm-timeout-ms=5000
+
+management.health.rabbit.enabled=false
+management.endpoints.web.exposure.include=health,prometheus,circuitbreaker
 management.endpoint.health.show-details=when_authorized
 management.metrics.tags.application=${spring.application.name}

--- a/services/questify-quest-service/src/main/resources/sql/schema.sql
+++ b/services/questify-quest-service/src/main/resources/sql/schema.sql
@@ -1,1 +1,27 @@
 CREATE SCHEMA IF NOT EXISTS quests;
+
+CREATE TABLE IF NOT EXISTS quests.outbox_events (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    routing_key VARCHAR(255) NOT NULL,
+    payload     TEXT         NOT NULL,
+    type_id     VARCHAR(512) NOT NULL,
+    status      VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    processed_at TIMESTAMPTZ,
+    attempts     INTEGER      NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ,
+    last_error   TEXT
+);
+
+ALTER TABLE quests.outbox_events ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE quests.outbox_events ADD COLUMN IF NOT EXISTS next_attempt_at TIMESTAMPTZ;
+ALTER TABLE quests.outbox_events ADD COLUMN IF NOT EXISTS last_error TEXT;
+
+UPDATE quests.outbox_events
+SET status = 'PENDING',
+    next_attempt_at = now()
+WHERE status = 'FAILED';
+
+CREATE INDEX IF NOT EXISTS idx_quest_outbox_pending_retry
+    ON quests.outbox_events (next_attempt_at, created_at)
+    WHERE status = 'PENDING';

--- a/services/questify-stats-service/src/main/resources/application.properties
+++ b/services/questify-stats-service/src/main/resources/application.properties
@@ -16,6 +16,7 @@ spring.rabbitmq.password=${RABBITMQ_PASSWORD:guest}
 
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
+management.health.rabbit.enabled=false
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=when_authorized
 management.metrics.tags.application=${spring.application.name}


### PR DESCRIPTION
Adds a circuit-breaker-protected RabbitMQ outbox flow. Events are persisted before publishing, retried with backoff, marked `SENT` after publisher confirms and moved to `DEAD` after repeated failures. This prevents event loss during RabbitMQ outages.