### PR TITLE
feat: add Redis cache-aside for stats and progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Questify is built as a **microservices** application:
 | `questify-admin-service` | Admin panel | 8086 |
 | `gateway` | Nginx reverse proxy | 8080 |
 | `frontend` | React/Vite UI | 80 |
+| `postgres` | Persistent data store | 5432 |
+| `rabbitmq` | Domain event broker | 5672 / 15672 |
+| `redis` | Cache-aside store for read models | 6379 |
 
 ## Getting Started
 
@@ -96,6 +99,12 @@ cd services/questify-<service-name>
 ```bash
 ./mvnw spotless:check  # Check formatting
 ./mvnw spotless:apply  # Fix formatting
+```
+
+**All services (run from repository root):**
+```bash
+make spotless        # Fix service formatting
+make spotless-check  # Check service formatting
 ```
 
 **Frontend:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,21 @@ services:
     networks:
       - questify-network
 
+  redis:
+    image: redis:7-alpine
+    container_name: questify-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - questify-network
+
   garage:
     build:
       context: ./services/garage
@@ -186,11 +201,14 @@ services:
       RABBITMQ_HOST: rabbitmq
       RABBITMQ_USERNAME: ${RABBITMQ_USER:-questify}
       RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-questify}
+      REDIS_HOST: redis
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173,http://localhost:80}
     depends_on:
       postgres:
         condition: service_healthy
       rabbitmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8084/actuator/health"]
@@ -217,11 +235,14 @@ services:
       RABBITMQ_HOST: rabbitmq
       RABBITMQ_USERNAME: ${RABBITMQ_USER:-questify}
       RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-questify}
+      REDIS_HOST: redis
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173,http://localhost:80}
     depends_on:
       postgres:
         condition: service_healthy
       rabbitmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8085/actuator/health"]
@@ -318,3 +339,4 @@ volumes:
   postgres-data:
   rabbitmq-data:
   garage-data:
+  redis-data:

--- a/services/questify-progression-service/pom.xml
+++ b/services/questify-progression-service/pom.xml
@@ -45,6 +45,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/config/CacheConfig.java
+++ b/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/config/CacheConfig.java
@@ -34,7 +34,7 @@ public class CacheConfig implements CachingConfigurer {
             .copy()
             .activateDefaultTyping(
                 LaissezFaireSubTypeValidator.instance,
-                ObjectMapper.DefaultTyping.NON_FINAL,
+                ObjectMapper.DefaultTyping.EVERYTHING,
                 JsonTypeInfo.As.PROPERTY);
 
     var serializer = new GenericJackson2JsonRedisSerializer(cacheMapper);

--- a/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/config/CacheConfig.java
+++ b/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/config/CacheConfig.java
@@ -1,0 +1,92 @@
+package com.axelfrache.questify.progression.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+@Slf4j
+public class CacheConfig implements CachingConfigurer {
+
+  @Value("${questify.cache.ttl-minutes:10}")
+  private long ttlMinutes;
+
+  @Bean
+  public RedisCacheManager cacheManager(RedisConnectionFactory factory, ObjectMapper objectMapper) {
+    var cacheMapper =
+        objectMapper
+            .copy()
+            .activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY);
+
+    var serializer = new GenericJackson2JsonRedisSerializer(cacheMapper);
+
+    var config =
+        RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(ttlMinutes))
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+            .disableCachingNullValues();
+
+    return RedisCacheManager.builder(factory).cacheDefaults(config).transactionAware().build();
+  }
+
+  @Override
+  public CacheErrorHandler errorHandler() {
+    return new CacheErrorHandler() {
+      @Override
+      public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+        log.warn(
+            "Cache get failed: cache={} key={} error={}",
+            cache.getName(),
+            key,
+            exception.toString());
+      }
+
+      @Override
+      public void handleCachePutError(
+          RuntimeException exception, Cache cache, Object key, Object value) {
+        log.warn(
+            "Cache put failed: cache={} key={} error={}",
+            cache.getName(),
+            key,
+            exception.toString());
+      }
+
+      @Override
+      public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+        log.warn(
+            "Cache evict failed: cache={} key={} error={}",
+            cache.getName(),
+            key,
+            exception.toString());
+      }
+
+      @Override
+      public void handleCacheClearError(RuntimeException exception, Cache cache) {
+        log.warn("Cache clear failed: cache={} error={}", cache.getName(), exception.toString());
+      }
+    };
+  }
+}

--- a/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/config/JacksonConfig.java
+++ b/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.axelfrache.questify.progression.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ObjectMapper objectMapper() {
+    return JsonMapper.builder()
+        .findAndAddModules()
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .build();
+  }
+}

--- a/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/messaging/UserDeletedListener.java
+++ b/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/messaging/UserDeletedListener.java
@@ -3,6 +3,7 @@ package com.axelfrache.questify.progression.messaging;
 import com.axelfrache.questify.progression.repository.QuestCompletionRecordRepository;
 import com.axelfrache.questify.progression.repository.UserAchievementRepository;
 import com.axelfrache.questify.progression.repository.UserProgressionRepository;
+import com.axelfrache.questify.progression.service.ProgressionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -17,6 +18,7 @@ public class UserDeletedListener {
   private final UserProgressionRepository userProgressionRepository;
   private final UserAchievementRepository userAchievementRepository;
   private final QuestCompletionRecordRepository questCompletionRecordRepository;
+  private final ProgressionService progressionService;
 
   @RabbitListener(queues = QueueConstants.USER_DELETED_QUEUE)
   @Transactional
@@ -25,5 +27,6 @@ public class UserDeletedListener {
     questCompletionRecordRepository.deleteByUserId(event.userId());
     userAchievementRepository.deleteByUserId(event.userId());
     userProgressionRepository.deleteByUserId(event.userId());
+    progressionService.evictUserCache(event.userId());
   }
 }

--- a/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/service/ProgressionService.java
+++ b/services/questify-progression-service/src/main/java/com/axelfrache/questify/progression/service/ProgressionService.java
@@ -11,6 +11,8 @@ import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,7 @@ public class ProgressionService {
   private final LevelConfig levelConfig;
 
   @Transactional
+  @CacheEvict(cacheNames = "progression", key = "#userId")
   public void awardXp(
       UUID userId, int amount, UUID questId, String categoryName, Instant completedAt) {
     var progression = findOrCreate(userId);
@@ -53,10 +56,14 @@ public class ProgressionService {
       log.info("User {} grade changed: {} -> {}", userId, previousGrade, newGrade);
   }
 
+  @Cacheable(cacheNames = "progression", key = "#userId")
   @Transactional(readOnly = true)
   public ProgressionResponse getProgression(UUID userId) {
     return toResponse(findOrCreate(userId));
   }
+
+  @CacheEvict(cacheNames = "progression", key = "#userId")
+  public void evictUserCache(UUID userId) {}
 
   private UserProgression findOrCreate(UUID userId) {
     return userProgressionRepository

--- a/services/questify-progression-service/src/main/resources/application.properties
+++ b/services/questify-progression-service/src/main/resources/application.properties
@@ -24,6 +24,8 @@ questify.level.multiplier=1.0
 
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.timeout=${REDIS_TIMEOUT:500ms}
+spring.data.redis.connect-timeout=${REDIS_CONNECT_TIMEOUT:500ms}
 spring.data.redis.repositories.enabled=false
 
 questify.cache.ttl-minutes=${CACHE_TTL_MINUTES:10}
@@ -31,6 +33,7 @@ questify.cache.ttl-minutes=${CACHE_TTL_MINUTES:10}
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
 management.health.rabbit.enabled=false
+management.health.redis.enabled=false
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=when_authorized
 management.metrics.tags.application=${spring.application.name}

--- a/services/questify-progression-service/src/main/resources/application.properties
+++ b/services/questify-progression-service/src/main/resources/application.properties
@@ -22,6 +22,12 @@ spring.rabbitmq.password=${RABBITMQ_PASSWORD:questify}
 questify.level.base-xp=100
 questify.level.multiplier=1.0
 
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.repositories.enabled=false
+
+questify.cache.ttl-minutes=${CACHE_TTL_MINUTES:10}
+
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
 management.health.rabbit.enabled=false

--- a/services/questify-stats-service/pom.xml
+++ b/services/questify-stats-service/pom.xml
@@ -45,6 +45,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/config/CacheConfig.java
+++ b/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/config/CacheConfig.java
@@ -1,0 +1,92 @@
+package com.axelfrache.questify.stats.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+@Slf4j
+public class CacheConfig implements CachingConfigurer {
+
+  @Value("${questify.cache.ttl-minutes:10}")
+  private long ttlMinutes;
+
+  @Bean
+  public RedisCacheManager cacheManager(RedisConnectionFactory factory, ObjectMapper objectMapper) {
+    var cacheMapper =
+        objectMapper
+            .copy()
+            .activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY);
+
+    var serializer = new GenericJackson2JsonRedisSerializer(cacheMapper);
+
+    var config =
+        RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(ttlMinutes))
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+            .disableCachingNullValues();
+
+    return RedisCacheManager.builder(factory).cacheDefaults(config).transactionAware().build();
+  }
+
+  @Override
+  public CacheErrorHandler errorHandler() {
+    return new CacheErrorHandler() {
+      @Override
+      public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+        log.warn(
+            "Cache get failed: cache={} key={} error={}",
+            cache.getName(),
+            key,
+            exception.toString());
+      }
+
+      @Override
+      public void handleCachePutError(
+          RuntimeException exception, Cache cache, Object key, Object value) {
+        log.warn(
+            "Cache put failed: cache={} key={} error={}",
+            cache.getName(),
+            key,
+            exception.toString());
+      }
+
+      @Override
+      public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+        log.warn(
+            "Cache evict failed: cache={} key={} error={}",
+            cache.getName(),
+            key,
+            exception.toString());
+      }
+
+      @Override
+      public void handleCacheClearError(RuntimeException exception, Cache cache) {
+        log.warn("Cache clear failed: cache={} error={}", cache.getName(), exception.toString());
+      }
+    };
+  }
+}

--- a/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/config/CacheConfig.java
+++ b/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/config/CacheConfig.java
@@ -34,7 +34,7 @@ public class CacheConfig implements CachingConfigurer {
             .copy()
             .activateDefaultTyping(
                 LaissezFaireSubTypeValidator.instance,
-                ObjectMapper.DefaultTyping.NON_FINAL,
+                ObjectMapper.DefaultTyping.EVERYTHING,
                 JsonTypeInfo.As.PROPERTY);
 
     var serializer = new GenericJackson2JsonRedisSerializer(cacheMapper);

--- a/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/config/JacksonConfig.java
+++ b/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.axelfrache.questify.stats.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ObjectMapper objectMapper() {
+    return JsonMapper.builder()
+        .findAndAddModules()
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .build();
+  }
+}

--- a/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/messaging/StatsEventListener.java
+++ b/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/messaging/StatsEventListener.java
@@ -2,6 +2,7 @@ package com.axelfrache.questify.stats.messaging;
 
 import com.axelfrache.questify.stats.model.QuestCompletionEntry;
 import com.axelfrache.questify.stats.repository.QuestCompletionEntryRepository;
+import com.axelfrache.questify.stats.service.StatsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class StatsEventListener {
 
   private final QuestCompletionEntryRepository repository;
+  private final StatsService statsService;
 
   @RabbitListener(queues = QueueConstants.QUEST_COMPLETED_QUEUE)
   @Transactional
@@ -28,6 +30,7 @@ public class StatsEventListener {
             .categoryName(event.categoryName())
             .completedAt(event.completedAt())
             .build());
+    statsService.evictUserCache(event.userId());
   }
 
   @RabbitListener(queues = QueueConstants.USER_DELETED_QUEUE)
@@ -35,5 +38,6 @@ public class StatsEventListener {
   public void onUserDeleted(UserDeletedEvent event) {
     log.info("Deleting stats for user {}", event.userId());
     repository.deleteByUserId(event.userId());
+    statsService.evictUserCache(event.userId());
   }
 }

--- a/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/service/StatsService.java
+++ b/services/questify-stats-service/src/main/java/com/axelfrache/questify/stats/service/StatsService.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -24,6 +27,7 @@ public class StatsService {
 
   private final QuestCompletionEntryRepository repository;
 
+  @Cacheable(cacheNames = "stats.overview", key = "#userId")
   @Transactional(readOnly = true)
   public OverallStatsResponse getOverallStats(UUID userId) {
     var total = repository.countTotalByUserId(userId);
@@ -46,11 +50,13 @@ public class StatsService {
                     e.getCompletedAt()));
   }
 
+  @Cacheable(cacheNames = "stats.categories", key = "#userId")
   @Transactional(readOnly = true)
   public List<CategoryStatsResponse> getCategoryStats(UUID userId) {
     return repository.findCategoryStatsByUserId(userId);
   }
 
+  @Cacheable(cacheNames = "stats.daily", key = "#userId + '-' + #days")
   @Transactional(readOnly = true)
   public List<DailyStatsResponse> getDailyStats(UUID userId, int days) {
     var today = LocalDate.now(ZoneOffset.UTC);
@@ -71,6 +77,14 @@ public class StatsService {
         .sorted(Comparator.comparing(DailyStatsResponse::date).reversed())
         .toList();
   }
+
+  @Caching(
+      evict = {
+        @CacheEvict(cacheNames = "stats.overview", key = "#userId"),
+        @CacheEvict(cacheNames = "stats.categories", key = "#userId"),
+        @CacheEvict(cacheNames = "stats.daily", allEntries = true)
+      })
+  public void evictUserCache(UUID userId) {}
 
   private int computeCurrentStreak(UUID userId) {
     var today = LocalDate.now(ZoneOffset.UTC);

--- a/services/questify-stats-service/src/main/resources/application.properties
+++ b/services/questify-stats-service/src/main/resources/application.properties
@@ -16,6 +16,8 @@ spring.rabbitmq.password=${RABBITMQ_PASSWORD:guest}
 
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.timeout=${REDIS_TIMEOUT:500ms}
+spring.data.redis.connect-timeout=${REDIS_CONNECT_TIMEOUT:500ms}
 spring.data.redis.repositories.enabled=false
 
 questify.cache.ttl-minutes=${CACHE_TTL_MINUTES:10}
@@ -23,6 +25,7 @@ questify.cache.ttl-minutes=${CACHE_TTL_MINUTES:10}
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
 management.health.rabbit.enabled=false
+management.health.redis.enabled=false
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=when_authorized
 management.metrics.tags.application=${spring.application.name}

--- a/services/questify-stats-service/src/main/resources/application.properties
+++ b/services/questify-stats-service/src/main/resources/application.properties
@@ -14,6 +14,12 @@ spring.rabbitmq.port=${RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${RABBITMQ_USERNAME:guest}
 spring.rabbitmq.password=${RABBITMQ_PASSWORD:guest}
 
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.repositories.enabled=false
+
+questify.cache.ttl-minutes=${CACHE_TTL_MINUTES:10}
+
 questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
 
 management.health.rabbit.enabled=false


### PR DESCRIPTION
Caches overview, category, daily stats, and user progression with a configurable TTL. Cache entries are evicted after relevant quest completion and user deletion events, with transaction-aware Redis cache management to avoid invalidating on rolled-back DB transactions.