### PR TITLE
feat: add notification-service with in-app notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - progression-service
           - stats-service
           - admin-service
+          - notification-service
     defaults:
       run:
         working-directory: services/questify-${{ matrix.service }}
@@ -88,6 +89,7 @@ jobs:
           - progression-service
           - stats-service
           - admin-service
+          - notification-service
     defaults:
       run:
         working-directory: services/questify-${{ matrix.service }}
@@ -154,6 +156,7 @@ jobs:
           - progression-service
           - stats-service
           - admin-service
+          - notification-service
     steps:
       - uses: actions/checkout@v4
 
@@ -269,6 +272,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Image | Registry |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|----------|" >> $GITHUB_STEP_SUMMARY
-          for svc in auth-service quest-service project-service progression-service stats-service admin-service frontend garage; do
+          for svc in auth-service quest-service project-service progression-service stats-service admin-service notification-service frontend garage; do
             echo "| \`${{ env.IMAGE_PREFIX }}-${svc}\` | docker.io |" >> $GITHUB_STEP_SUMMARY
           done

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SERVICES := \
 	questify-admin-service \
 	questify-auth-service \
+	questify-notification-service \
 	questify-progression-service \
 	questify-project-service \
 	questify-quest-service \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -290,6 +290,40 @@ services:
     networks:
       - questify-network
 
+  notification-service:
+    build:
+      context: ./services
+      dockerfile: questify-notification-service/Dockerfile
+    container_name: questify-notification-service
+    ports:
+      - "8087:8087"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-questify}
+      SPRING_DATASOURCE_USERNAME: ${NOTIFICATION_DB_USER:-notification_svc}
+      SPRING_DATASOURCE_PASSWORD: ${NOTIFICATION_DB_PASSWORD:-notification_svc}
+      SPRING_DATASOURCE_DRIVER: org.postgresql.Driver
+      SPRING_JPA_DDL_AUTO: update
+      RABBITMQ_HOST: rabbitmq
+      RABBITMQ_USERNAME: ${RABBITMQ_USER:-questify}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-questify}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173,http://localhost:80}
+      VAPID_PUBLIC_KEY: ${VAPID_PUBLIC_KEY:-}
+      VAPID_PRIVATE_KEY: ${VAPID_PRIVATE_KEY:-}
+      VAPID_SUBJECT: ${VAPID_SUBJECT:-mailto:admin@questify.local}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8087/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    networks:
+      - questify-network
+
   gateway:
     image: nginx:alpine
     container_name: questify-gateway
@@ -309,6 +343,8 @@ services:
       stats-service:
         condition: service_healthy
       admin-service:
+        condition: service_healthy
+      notification-service:
         condition: service_healthy
     networks:
       - questify-network

--- a/frontend/src/hooks/useInboxState.ts
+++ b/frontend/src/hooks/useInboxState.ts
@@ -46,7 +46,11 @@ function saveToStorage<T>(key: string, value: T): void {
   } catch {} // eslint-disable-line no-empty
 }
 
-export function useInboxState(allQuests: QuestResponse[], pinnedProjectIds: string[] = []) {
+export function useInboxState(
+  allQuests: QuestResponse[],
+  pinnedProjectIds: string[] = [],
+  projects: Array<{ id: string; name: string; icon: string }> = []
+) {
   const [search, setSearchRaw] = useState('');
   const [groupBy, setGroupByRaw] = useState<GroupBy>(() =>
     sanitizeGroupBy(loadFromStorage<unknown>(GROUPBY_KEY, DEFAULT_INBOX_STATE.groupBy))
@@ -179,11 +183,11 @@ export function useInboxState(allQuests: QuestResponse[], pinnedProjectIds: stri
     }
 
     if (groupBy === 'project') {
-      return groupByProject(processedQuests, collapsedRegions, pinnedProjectIds);
+      return groupByProject(processedQuests, collapsedRegions, pinnedProjectIds, projects);
     }
 
     return groupByRegion(processedQuests, pinnedRegions, collapsedRegions);
-  }, [groupBy, processedQuests, collapsedRegions, pinnedProjectIds, pinnedRegions]);
+  }, [groupBy, processedQuests, collapsedRegions, pinnedProjectIds, pinnedRegions, projects]);
 
   const paginatedQuests = useMemo(() => {
     return processedQuests.slice(0, page * pageSize);

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -37,7 +37,7 @@ export function AppLayout() {
       <div className="flex min-h-svh w-full">
         <AppSidebar />
         <div className="flex flex-1 flex-col min-w-0">
-          <header className="flex h-12 items-center gap-3 border-b bg-card px-4 sticky top-0 z-10">
+          <header className="flex h-12 items-center gap-3 border-b bg-card px-4 sticky top-0 z-20">
             <SidebarTrigger className="h-8 w-8" />
             {title && (
               <span className="text-[13px] font-medium tracking-tight text-foreground">

--- a/frontend/src/lib/inboxUtils.ts
+++ b/frontend/src/lib/inboxUtils.ts
@@ -112,11 +112,13 @@ export function groupByRegion(
 export function groupByProject(
   quests: QuestResponse[],
   collapsedSections: Set<string>,
-  pinnedProjectIds: string[]
+  pinnedProjectIds: string[],
+  projects: Array<{ id: string; name: string; icon: string }> = []
 ): GroupedQuests[] {
   const looseSectionId = '__loose__';
   const looseQuests: QuestResponse[] = [];
   const projectMap = new Map<string, QuestResponse[]>();
+  const projectInfoMap = new Map(projects.map((p) => [p.id, { name: p.name, icon: p.icon }]));
 
   for (const quest of quests) {
     const projectId = quest.projectId;
@@ -133,10 +135,11 @@ export function groupByProject(
 
   const projectGroups: GroupedQuests[] = [];
   for (const [projectId, projectQuests] of projectMap) {
+    const info = projectInfoMap.get(projectId);
     projectGroups.push({
       regionId: projectId,
-      regionName: 'Project',
-      regionIcon: '📁',
+      regionName: info?.name ?? 'Project',
+      regionIcon: info?.icon ?? '📁',
       regionColor: '#0ea5e9',
       quests: projectQuests,
       totalCount: projectQuests.length,

--- a/frontend/src/pages/InboxPage.tsx
+++ b/frontend/src/pages/InboxPage.tsx
@@ -82,6 +82,16 @@ export function InboxPage() {
     [projectSidebar]
   );
 
+  const allProjects = useMemo(() => {
+    if (!projectSidebar) return [];
+    const seen = new Set<string>();
+    return [...(projectSidebar.pinned ?? []), ...(projectSidebar.recent ?? [])].filter((p) => {
+      if (seen.has(p.id)) return false;
+      seen.add(p.id);
+      return true;
+    });
+  }, [projectSidebar]);
+
   const {
     search,
     groupBy,
@@ -104,7 +114,7 @@ export function InboxPage() {
     togglePinRegion,
     toggleCollapseRegion,
     loadMore,
-  } = useInboxState(pendingQuests, pinnedProjectIds);
+  } = useInboxState(pendingQuests, pinnedProjectIds, allProjects);
 
   const handleComplete = (id: string, checkboxElement?: HTMLElement) => {
     if (checkboxElement) {

--- a/services/db/init.sh
+++ b/services/db/init.sh
@@ -6,18 +6,21 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     CREATE USER project_svc     WITH PASSWORD '${PROJECT_DB_PASSWORD:-project_svc}';
     CREATE USER progression_svc WITH PASSWORD '${PROGRESSION_DB_PASSWORD:-progression_svc}';
     CREATE USER stats_svc       WITH PASSWORD '${STATS_DB_PASSWORD:-stats_svc}';
-    CREATE USER admin_svc       WITH PASSWORD '${ADMIN_DB_PASSWORD:-admin_svc}';
+    CREATE USER admin_svc         WITH PASSWORD '${ADMIN_DB_PASSWORD:-admin_svc}';
+    CREATE USER notification_svc  WITH PASSWORD '${NOTIFICATION_DB_PASSWORD:-notification_svc}';
 
     GRANT CONNECT, CREATE ON DATABASE $POSTGRES_DB TO quest_svc;
     GRANT CONNECT, CREATE ON DATABASE $POSTGRES_DB TO project_svc;
     GRANT CONNECT, CREATE ON DATABASE $POSTGRES_DB TO progression_svc;
     GRANT CONNECT, CREATE ON DATABASE $POSTGRES_DB TO stats_svc;
     GRANT CONNECT, CREATE ON DATABASE $POSTGRES_DB TO admin_svc;
+    GRANT CONNECT, CREATE ON DATABASE $POSTGRES_DB TO notification_svc;
 
     CREATE SCHEMA IF NOT EXISTS auth;
-    CREATE SCHEMA IF NOT EXISTS quests       AUTHORIZATION quest_svc;
-    CREATE SCHEMA IF NOT EXISTS projects     AUTHORIZATION project_svc;
-    CREATE SCHEMA IF NOT EXISTS progression  AUTHORIZATION progression_svc;
-    CREATE SCHEMA IF NOT EXISTS stats        AUTHORIZATION stats_svc;
-    CREATE SCHEMA IF NOT EXISTS admin        AUTHORIZATION admin_svc;
+    CREATE SCHEMA IF NOT EXISTS quests        AUTHORIZATION quest_svc;
+    CREATE SCHEMA IF NOT EXISTS projects      AUTHORIZATION project_svc;
+    CREATE SCHEMA IF NOT EXISTS progression   AUTHORIZATION progression_svc;
+    CREATE SCHEMA IF NOT EXISTS stats         AUTHORIZATION stats_svc;
+    CREATE SCHEMA IF NOT EXISTS admin         AUTHORIZATION admin_svc;
+    CREATE SCHEMA IF NOT EXISTS notifications AUTHORIZATION notification_svc;
 EOSQL

--- a/services/gateway/nginx.conf
+++ b/services/gateway/nginx.conf
@@ -14,7 +14,8 @@ http {
         set $project_svc     "project-service:8083";
         set $progression_svc "progression-service:8084";
         set $stats_svc       "stats-service:8085";
-        set $admin_svc       "admin-service:8086";
+        set $admin_svc           "admin-service:8086";
+        set $notification_svc    "notification-service:8087";
 
         location = /_auth/validate {
             internal;
@@ -90,6 +91,16 @@ http {
             auth_request_set $x_user_id   $upstream_http_x_user_id;
             auth_request_set $x_user_role $upstream_http_x_user_role;
             proxy_pass       http://$admin_svc;
+            proxy_set_header X-User-Id   $x_user_id;
+            proxy_set_header X-User-Role $x_user_role;
+            proxy_set_header Host        $host;
+        }
+
+        location /api/notifications {
+            auth_request     /_auth/validate;
+            auth_request_set $x_user_id   $upstream_http_x_user_id;
+            auth_request_set $x_user_role $upstream_http_x_user_role;
+            proxy_pass       http://$notification_svc;
             proxy_set_header X-User-Id   $x_user_id;
             proxy_set_header X-User-Role $x_user_role;
             proxy_set_header Host        $host;

--- a/services/questify-notification-service/.mvn/wrapper/maven-wrapper.properties
+++ b/services/questify-notification-service/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/services/questify-notification-service/Dockerfile
+++ b/services/questify-notification-service/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:21-jdk-alpine AS build
+
+WORKDIR /app
+
+COPY questify-notification-service/.mvn/ .mvn/
+COPY questify-notification-service/mvnw questify-notification-service/pom.xml ./
+
+RUN chmod +x mvnw && ./mvnw dependency:go-offline -B
+
+COPY questify-notification-service/src/ src/
+
+RUN ./mvnw package -DskipTests -B
+
+FROM eclipse-temurin:21-jre-alpine AS runtime
+
+LABEL org.opencontainers.image.title="Questify Notification Service"
+LABEL org.opencontainers.image.source="https://github.com/axelfrache/questify"
+
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+
+WORKDIR /app
+
+COPY --from=build --chown=appuser:appgroup /app/target/*.jar app.jar
+
+USER appuser
+
+EXPOSE 8087
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8087/actuator/health || exit 1
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/questify-notification-service/mvnw
+++ b/services/questify-notification-service/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/services/questify-notification-service/pom.xml
+++ b/services/questify-notification-service/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.1</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.axelfrache.questify</groupId>
+    <artifactId>questify-notification-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Questify Notification Service</name>
+    <description>In-app notifications and push reminders for quests</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+        <!-- Web Push (VAPID) -->
+        <dependency>
+            <groupId>nl.martijndwars</groupId>
+            <artifactId>web-push</artifactId>
+            <version>5.1.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.44.4</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat>
+                            <version>1.25.2</version>
+                            <style>GOOGLE</style>
+                        </googleJavaFormat>
+                        <removeUnusedImports/>
+                        <formatAnnotations/>
+                    </java>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/NotificationServiceApplication.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/NotificationServiceApplication.java
@@ -1,0 +1,14 @@
+package com.axelfrache.questify.notification;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class NotificationServiceApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(NotificationServiceApplication.class, args);
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/config/JacksonConfig.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.axelfrache.questify.notification.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ObjectMapper objectMapper() {
+    return JsonMapper.builder()
+        .findAndAddModules()
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .build();
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/config/RabbitMQConfig.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/config/RabbitMQConfig.java
@@ -1,0 +1,60 @@
+package com.axelfrache.questify.notification.config;
+
+import com.axelfrache.questify.notification.messaging.QueueConstants;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+  @Bean
+  public TopicExchange questifyExchange() {
+    return new TopicExchange(QueueConstants.EXCHANGE, true, false);
+  }
+
+  @Bean
+  public Queue questScheduledQueue() {
+    return new Queue(QueueConstants.QUEST_SCHEDULED_QUEUE, true);
+  }
+
+  @Bean
+  public Queue questCompletedQueue() {
+    return new Queue(QueueConstants.QUEST_COMPLETED_QUEUE, true);
+  }
+
+  @Bean
+  public Queue userDeletedQueue() {
+    return new Queue(QueueConstants.USER_DELETED_QUEUE, true);
+  }
+
+  @Bean
+  public Binding questScheduledBinding(Queue questScheduledQueue, TopicExchange questifyExchange) {
+    return BindingBuilder.bind(questScheduledQueue)
+        .to(questifyExchange)
+        .with(QueueConstants.QUEST_SCHEDULED_ROUTING_KEY);
+  }
+
+  @Bean
+  public Binding questCompletedBinding(Queue questCompletedQueue, TopicExchange questifyExchange) {
+    return BindingBuilder.bind(questCompletedQueue)
+        .to(questifyExchange)
+        .with(QueueConstants.QUEST_COMPLETED_ROUTING_KEY);
+  }
+
+  @Bean
+  public Binding userDeletedBinding(Queue userDeletedQueue, TopicExchange questifyExchange) {
+    return BindingBuilder.bind(userDeletedQueue)
+        .to(questifyExchange)
+        .with(QueueConstants.USER_DELETED_ROUTING_KEY);
+  }
+
+  @Bean
+  public Jackson2JsonMessageConverter messageConverter() {
+    return new Jackson2JsonMessageConverter();
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/config/SecurityConfig.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.axelfrache.questify.notification.config;
+
+import com.axelfrache.questify.notification.security.HeaderAuthenticationFilter;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  @Value("${questify.cors.allowed-origins}")
+  private String allowedOrigins;
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    return http.csrf(AbstractHttpConfigurer::disable)
+        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .addFilterBefore(
+            new HeaderAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/actuator/health", "/actuator/prometheus")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    var config = new CorsConfiguration();
+    config.setAllowedOrigins(Arrays.stream(allowedOrigins.split(",")).map(String::trim).toList());
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setExposedHeaders(List.of("X-User-Id", "X-User-Role"));
+    config.setAllowCredentials(true);
+
+    var source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/controller/NotificationController.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/controller/NotificationController.java
@@ -1,0 +1,81 @@
+package com.axelfrache.questify.notification.controller;
+
+import com.axelfrache.questify.notification.dto.NotificationResponse;
+import com.axelfrache.questify.notification.dto.PushSubscriptionRequest;
+import com.axelfrache.questify.notification.dto.UnreadCountResponse;
+import com.axelfrache.questify.notification.service.NotificationService;
+import com.axelfrache.questify.notification.service.PushNotificationService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationService notificationService;
+  private final PushNotificationService pushNotificationService;
+
+  @GetMapping
+  public List<NotificationResponse> getNotifications(@AuthenticationPrincipal String userId) {
+    return notificationService.getNotifications(UUID.fromString(userId));
+  }
+
+  @GetMapping("/unread-count")
+  public UnreadCountResponse getUnreadCount(@AuthenticationPrincipal String userId) {
+    return new UnreadCountResponse(notificationService.getUnreadCount(UUID.fromString(userId)));
+  }
+
+  @PatchMapping("/{id}/read")
+  public ResponseEntity<Void> markRead(
+      @PathVariable UUID id, @AuthenticationPrincipal String userId) {
+    notificationService.markRead(id, UUID.fromString(userId));
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/read-all")
+  public ResponseEntity<Void> markAllRead(@AuthenticationPrincipal String userId) {
+    notificationService.markAllRead(UUID.fromString(userId));
+    return ResponseEntity.noContent().build();
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(
+      @PathVariable UUID id, @AuthenticationPrincipal String userId) {
+    notificationService.delete(id, UUID.fromString(userId));
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/push/status")
+  public Map<String, Boolean> getPushStatus() {
+    return Map.of("enabled", pushNotificationService.isPushEnabled());
+  }
+
+  @PostMapping("/push/subscribe")
+  public ResponseEntity<Void> subscribe(
+      @AuthenticationPrincipal String userId, @RequestBody @Valid PushSubscriptionRequest request) {
+    notificationService.subscribe(UUID.fromString(userId), request);
+    return ResponseEntity.noContent().build();
+  }
+
+  @DeleteMapping("/push/subscribe")
+  public ResponseEntity<Void> unsubscribe(
+      @AuthenticationPrincipal String userId, @RequestParam String endpoint) {
+    notificationService.unsubscribe(UUID.fromString(userId), endpoint);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/dto/NotificationResponse.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/dto/NotificationResponse.java
@@ -1,0 +1,14 @@
+package com.axelfrache.questify.notification.dto;
+
+import com.axelfrache.questify.notification.model.NotificationType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationResponse(
+    UUID id,
+    NotificationType type,
+    String title,
+    String body,
+    UUID questId,
+    boolean read,
+    Instant createdAt) {}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/dto/PushSubscriptionRequest.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/dto/PushSubscriptionRequest.java
@@ -1,0 +1,6 @@
+package com.axelfrache.questify.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PushSubscriptionRequest(
+    @NotBlank String endpoint, @NotBlank String p256dh, @NotBlank String auth) {}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/dto/UnreadCountResponse.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/dto/UnreadCountResponse.java
@@ -1,0 +1,3 @@
+package com.axelfrache.questify.notification.dto;
+
+public record UnreadCountResponse(long count) {}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/exception/GlobalExceptionHandler.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.axelfrache.questify.notification.exception;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException e) {
+    return ResponseEntity.badRequest()
+        .body(Map.of("error", e.getMessage(), "timestamp", Instant.now().toString()));
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Map<String, Object>> handleGeneric(Exception e) {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(Map.of("error", "Internal server error", "timestamp", Instant.now().toString()));
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QuestCompletedEvent.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QuestCompletedEvent.java
@@ -1,0 +1,12 @@
+package com.axelfrache.questify.notification.messaging;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record QuestCompletedEvent(
+    UUID userId,
+    UUID questId,
+    String questTitle,
+    int xpEarned,
+    String categoryName,
+    Instant completedAt) {}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QuestCompletedListener.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QuestCompletedListener.java
@@ -1,0 +1,36 @@
+package com.axelfrache.questify.notification.messaging;
+
+import com.axelfrache.questify.notification.model.NotificationType;
+import com.axelfrache.questify.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class QuestCompletedListener {
+
+  private final NotificationService notificationService;
+
+  @RabbitListener(queues = QueueConstants.QUEST_COMPLETED_QUEUE)
+  @Transactional
+  public void onQuestCompleted(QuestCompletedEvent event) {
+    log.debug(
+        "Received quest.completed: userId={} quest={} xp={}",
+        event.userId(),
+        event.questTitle(),
+        event.xpEarned());
+
+    notificationService.markReminderCompleted(event.userId(), event.questId());
+
+    notificationService.createAndSendNotification(
+        event.userId(),
+        NotificationType.QUEST_COMPLETED,
+        "Quest completed! 🎉",
+        "+" + event.xpEarned() + " XP — \"" + event.questTitle() + "\"",
+        event.questId());
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QuestScheduledEvent.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QuestScheduledEvent.java
@@ -1,0 +1,6 @@
+package com.axelfrache.questify.notification.messaging;
+
+import java.util.UUID;
+
+public record QuestScheduledEvent(
+    UUID userId, UUID templateId, UUID occurrenceId, String questTitle, String scheduledDate) {}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QuestScheduledListener.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QuestScheduledListener.java
@@ -1,0 +1,27 @@
+package com.axelfrache.questify.notification.messaging;
+
+import com.axelfrache.questify.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class QuestScheduledListener {
+
+  private final NotificationService notificationService;
+
+  @RabbitListener(queues = QueueConstants.QUEST_SCHEDULED_QUEUE)
+  @Transactional
+  public void onQuestScheduled(QuestScheduledEvent event) {
+    log.debug(
+        "Received quest.scheduled: userId={} title={} date={}",
+        event.userId(),
+        event.questTitle(),
+        event.scheduledDate());
+    notificationService.createScheduledReminder(event);
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QueueConstants.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/QueueConstants.java
@@ -1,0 +1,16 @@
+package com.axelfrache.questify.notification.messaging;
+
+public final class QueueConstants {
+
+  private QueueConstants() {}
+
+  public static final String EXCHANGE = "questify.events";
+
+  public static final String QUEST_SCHEDULED_ROUTING_KEY = "quest.scheduled";
+  public static final String QUEST_COMPLETED_ROUTING_KEY = "quest.completed";
+  public static final String USER_DELETED_ROUTING_KEY = "user.deleted";
+
+  public static final String QUEST_SCHEDULED_QUEUE = "notification-service.quest-scheduled";
+  public static final String QUEST_COMPLETED_QUEUE = "notification-service.quest-completed";
+  public static final String USER_DELETED_QUEUE = "notification-service.user-deleted";
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/UserDeletedEvent.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/UserDeletedEvent.java
@@ -1,0 +1,5 @@
+package com.axelfrache.questify.notification.messaging;
+
+import java.util.UUID;
+
+public record UserDeletedEvent(UUID userId) {}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/UserDeletedListener.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/messaging/UserDeletedListener.java
@@ -1,0 +1,23 @@
+package com.axelfrache.questify.notification.messaging;
+
+import com.axelfrache.questify.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserDeletedListener {
+
+  private final NotificationService notificationService;
+
+  @RabbitListener(queues = QueueConstants.USER_DELETED_QUEUE)
+  @Transactional
+  public void onUserDeleted(UserDeletedEvent event) {
+    log.info("Received user.deleted: userId={}", event.userId());
+    notificationService.deleteUserData(event.userId());
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/model/Notification.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/model/Notification.java
@@ -1,0 +1,59 @@
+package com.axelfrache.questify.notification.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(schema = "notifications", name = "notifications")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false)
+  private UUID userId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 50)
+  private NotificationType type;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String title;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String body;
+
+  private UUID questId;
+
+  @Builder.Default
+  @Column(nullable = false)
+  private boolean read = false;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+
+  @PrePersist
+  void prePersist() {
+    if (createdAt == null) createdAt = Instant.now();
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/model/NotificationType.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/model/NotificationType.java
@@ -1,0 +1,7 @@
+package com.axelfrache.questify.notification.model;
+
+public enum NotificationType {
+  QUEST_DUE_SOON,
+  QUEST_OVERDUE,
+  QUEST_COMPLETED
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/model/PushSubscription.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/model/PushSubscription.java
@@ -1,0 +1,49 @@
+package com.axelfrache.questify.notification.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(schema = "notifications", name = "push_subscriptions")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushSubscription {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false)
+  private UUID userId;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String endpoint;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String p256dh;
+
+  @Column(nullable = false, columnDefinition = "text", name = "auth_key")
+  private String authKey;
+
+  private Instant createdAt;
+
+  @PrePersist
+  void prePersist() {
+    if (createdAt == null) createdAt = Instant.now();
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/model/ScheduledReminder.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/model/ScheduledReminder.java
@@ -1,0 +1,71 @@
+package com.axelfrache.questify.notification.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(schema = "notifications", name = "scheduled_reminders")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduledReminder {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false)
+  private UUID userId;
+
+  @Column(nullable = false)
+  private UUID templateId;
+
+  private UUID occurrenceId;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String questTitle;
+
+  @Column(nullable = false)
+  private LocalDate scheduledDate;
+
+  @Builder.Default
+  @Column(nullable = false)
+  private boolean reminderSent = false;
+
+  @Builder.Default
+  @Column(nullable = false)
+  private boolean completed = false;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+
+  @Column(nullable = false)
+  private Instant updatedAt;
+
+  @PrePersist
+  void prePersist() {
+    createdAt = Instant.now();
+    updatedAt = Instant.now();
+  }
+
+  @PreUpdate
+  void preUpdate() {
+    updatedAt = Instant.now();
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/repository/NotificationRepository.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/repository/NotificationRepository.java
@@ -1,0 +1,37 @@
+package com.axelfrache.questify.notification.repository;
+
+import com.axelfrache.questify.notification.model.Notification;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+  List<Notification> findByUserIdOrderByCreatedAtDesc(UUID userId);
+
+  long countByUserIdAndReadFalse(UUID userId);
+
+  @Modifying
+  @Query("UPDATE Notification n SET n.read = true WHERE n.userId = :userId AND n.read = false")
+  int markAllReadByUserId(UUID userId);
+
+  void deleteByUserId(UUID userId);
+
+  @Query(
+      value =
+          """
+          DELETE FROM notifications.notifications
+          WHERE user_id = :userId
+            AND id NOT IN (
+              SELECT id FROM notifications.notifications
+              WHERE user_id = :userId
+              ORDER BY created_at DESC
+              LIMIT :maxCount
+            )
+          """,
+      nativeQuery = true)
+  @Modifying
+  void pruneOldestForUser(UUID userId, int maxCount);
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/repository/PushSubscriptionRepository.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/repository/PushSubscriptionRepository.java
@@ -1,0 +1,18 @@
+package com.axelfrache.questify.notification.repository;
+
+import com.axelfrache.questify.notification.model.PushSubscription;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, UUID> {
+
+  List<PushSubscription> findByUserId(UUID userId);
+
+  Optional<PushSubscription> findByUserIdAndEndpoint(UUID userId, String endpoint);
+
+  void deleteByUserIdAndEndpoint(UUID userId, String endpoint);
+
+  void deleteByUserId(UUID userId);
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/repository/ScheduledReminderRepository.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/repository/ScheduledReminderRepository.java
@@ -1,0 +1,25 @@
+package com.axelfrache.questify.notification.repository;
+
+import com.axelfrache.questify.notification.model.ScheduledReminder;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ScheduledReminderRepository extends JpaRepository<ScheduledReminder, UUID> {
+
+  Optional<ScheduledReminder> findByUserIdAndOccurrenceId(UUID userId, UUID occurrenceId);
+
+  @Query(
+      """
+      SELECT r FROM ScheduledReminder r
+      WHERE r.reminderSent = false
+        AND r.completed = false
+        AND r.scheduledDate <= :cutoffDate
+      """)
+  List<ScheduledReminder> findDueReminders(LocalDate cutoffDate);
+
+  void deleteByUserId(UUID userId);
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/scheduler/ReminderScheduler.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/scheduler/ReminderScheduler.java
@@ -1,0 +1,55 @@
+package com.axelfrache.questify.notification.scheduler;
+
+import com.axelfrache.questify.notification.model.NotificationType;
+import com.axelfrache.questify.notification.repository.ScheduledReminderRepository;
+import com.axelfrache.questify.notification.service.NotificationService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReminderScheduler {
+
+  private final ScheduledReminderRepository scheduledReminderRepository;
+  private final NotificationService notificationService;
+
+  @Value("${questify.reminder.hours-before:24}")
+  private int hoursBefore;
+
+  @Scheduled(fixedDelayString = "${questify.reminder.check-delay-ms:900000}")
+  public void checkReminders() {
+    var cutoff = LocalDate.now().plusDays((hoursBefore + 23) / 24);
+    var due = scheduledReminderRepository.findDueReminders(cutoff);
+
+    if (due.isEmpty()) return;
+
+    log.debug("Processing {} due reminders", due.size());
+
+    for (var reminder : due) {
+      try {
+        var today = LocalDate.now();
+        var isOverdue = reminder.getScheduledDate().isBefore(today);
+
+        var type = isOverdue ? NotificationType.QUEST_OVERDUE : NotificationType.QUEST_DUE_SOON;
+        var title = isOverdue ? "Quest overdue ⚠️" : "Quest due soon ⏰";
+        var body =
+            isOverdue
+                ? "\"" + reminder.getQuestTitle() + "\" is overdue"
+                : "\"" + reminder.getQuestTitle() + "\" is due today";
+
+        notificationService.createAndSendNotification(
+            reminder.getUserId(), type, title, body, reminder.getTemplateId());
+
+        reminder.setReminderSent(true);
+        scheduledReminderRepository.save(reminder);
+      } catch (Exception e) {
+        log.warn("Failed to process reminder {}: {}", reminder.getId(), e.getMessage());
+      }
+    }
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/security/HeaderAuthenticationFilter.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/security/HeaderAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package com.axelfrache.questify.notification.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class HeaderAuthenticationFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    var userId = request.getHeader("X-User-Id");
+    var userRole = request.getHeader("X-User-Role");
+
+    if (userId != null && !userId.isBlank()) {
+      var authorities =
+          userRole != null && !userRole.isBlank()
+              ? List.of(new SimpleGrantedAuthority("ROLE_" + userRole))
+              : List.<SimpleGrantedAuthority>of();
+
+      var auth = new UsernamePasswordAuthenticationToken(userId, null, authorities);
+      SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/service/NotificationService.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/service/NotificationService.java
@@ -1,0 +1,172 @@
+package com.axelfrache.questify.notification.service;
+
+import com.axelfrache.questify.notification.dto.NotificationResponse;
+import com.axelfrache.questify.notification.dto.PushSubscriptionRequest;
+import com.axelfrache.questify.notification.messaging.QuestScheduledEvent;
+import com.axelfrache.questify.notification.model.Notification;
+import com.axelfrache.questify.notification.model.NotificationType;
+import com.axelfrache.questify.notification.model.PushSubscription;
+import com.axelfrache.questify.notification.model.ScheduledReminder;
+import com.axelfrache.questify.notification.repository.NotificationRepository;
+import com.axelfrache.questify.notification.repository.PushSubscriptionRepository;
+import com.axelfrache.questify.notification.repository.ScheduledReminderRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final ScheduledReminderRepository scheduledReminderRepository;
+  private final PushSubscriptionRepository pushSubscriptionRepository;
+  private final PushNotificationService pushNotificationService;
+
+  @Value("${questify.notification.max-per-user:100}")
+  private int maxPerUser;
+
+  @Transactional(readOnly = true)
+  public List<NotificationResponse> getNotifications(UUID userId) {
+    return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public long getUnreadCount(UUID userId) {
+    return notificationRepository.countByUserIdAndReadFalse(userId);
+  }
+
+  @Transactional
+  public void markRead(UUID notificationId, UUID userId) {
+    notificationRepository
+        .findById(notificationId)
+        .filter(n -> n.getUserId().equals(userId))
+        .ifPresent(
+            n -> {
+              n.setRead(true);
+              notificationRepository.save(n);
+            });
+  }
+
+  @Transactional
+  public void markAllRead(UUID userId) {
+    notificationRepository.markAllReadByUserId(userId);
+  }
+
+  @Transactional
+  public void delete(UUID notificationId, UUID userId) {
+    notificationRepository
+        .findById(notificationId)
+        .filter(n -> n.getUserId().equals(userId))
+        .ifPresent(notificationRepository::delete);
+  }
+
+  @Transactional
+  public void createScheduledReminder(QuestScheduledEvent event) {
+    if (event.occurrenceId() == null) return;
+
+    var existing =
+        scheduledReminderRepository.findByUserIdAndOccurrenceId(
+            event.userId(), event.occurrenceId());
+
+    var scheduledDate = LocalDate.parse(event.scheduledDate());
+
+    if (existing.isPresent()) {
+      var reminder = existing.get();
+      reminder.setQuestTitle(event.questTitle());
+      reminder.setScheduledDate(scheduledDate);
+      reminder.setReminderSent(false);
+      scheduledReminderRepository.save(reminder);
+    } else {
+      scheduledReminderRepository.save(
+          ScheduledReminder.builder()
+              .userId(event.userId())
+              .templateId(event.templateId())
+              .occurrenceId(event.occurrenceId())
+              .questTitle(event.questTitle())
+              .scheduledDate(scheduledDate)
+              .build());
+    }
+  }
+
+  @Transactional
+  public void markReminderCompleted(UUID userId, UUID occurrenceId) {
+    scheduledReminderRepository
+        .findByUserIdAndOccurrenceId(userId, occurrenceId)
+        .ifPresent(
+            r -> {
+              r.setCompleted(true);
+              scheduledReminderRepository.save(r);
+            });
+  }
+
+  @Transactional
+  public void createAndSendNotification(
+      UUID userId, NotificationType type, String title, String body, UUID questId) {
+    var notification =
+        notificationRepository.save(
+            Notification.builder()
+                .userId(userId)
+                .type(type)
+                .title(title)
+                .body(body)
+                .questId(questId)
+                .build());
+
+    notificationRepository.pruneOldestForUser(userId, maxPerUser);
+
+    var subscriptions = pushSubscriptionRepository.findByUserId(userId);
+    for (var sub : subscriptions) {
+      pushNotificationService.send(sub, title, body);
+    }
+
+    log.debug("Notification created: type={} userId={} questId={}", type, userId, questId);
+  }
+
+  @Transactional
+  public void subscribe(UUID userId, PushSubscriptionRequest request) {
+    pushSubscriptionRepository
+        .findByUserIdAndEndpoint(userId, request.endpoint())
+        .orElseGet(
+            () ->
+                pushSubscriptionRepository.save(
+                    PushSubscription.builder()
+                        .userId(userId)
+                        .endpoint(request.endpoint())
+                        .p256dh(request.p256dh())
+                        .authKey(request.auth())
+                        .build()));
+  }
+
+  @Transactional
+  public void unsubscribe(UUID userId, String endpoint) {
+    pushSubscriptionRepository.deleteByUserIdAndEndpoint(userId, endpoint);
+  }
+
+  @Transactional
+  public void deleteUserData(UUID userId) {
+    notificationRepository.deleteByUserId(userId);
+    scheduledReminderRepository.deleteByUserId(userId);
+    pushSubscriptionRepository.deleteByUserId(userId);
+    log.info("Deleted all notification data for userId={}", userId);
+  }
+
+  private NotificationResponse toResponse(Notification n) {
+    return new NotificationResponse(
+        n.getId(),
+        n.getType(),
+        n.getTitle(),
+        n.getBody(),
+        n.getQuestId(),
+        n.isRead(),
+        n.getCreatedAt());
+  }
+}

--- a/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/service/PushNotificationService.java
+++ b/services/questify-notification-service/src/main/java/com/axelfrache/questify/notification/service/PushNotificationService.java
@@ -1,0 +1,78 @@
+package com.axelfrache.questify.notification.service;
+
+import com.axelfrache.questify.notification.model.PushSubscription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import java.security.Security;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PushNotificationService {
+
+  @Value("${vapid.public-key:}")
+  private String vapidPublicKey;
+
+  @Value("${vapid.private-key:}")
+  private String vapidPrivateKey;
+
+  @Value("${vapid.subject:mailto:admin@questify.local}")
+  private String vapidSubject;
+
+  private final ObjectMapper objectMapper;
+
+  private PushService pushService;
+  private boolean pushEnabled = false;
+
+  @PostConstruct
+  void init() {
+    if (vapidPublicKey.isBlank() || vapidPrivateKey.isBlank()) {
+      log.info("VAPID keys not configured — push notifications disabled");
+      return;
+    }
+    try {
+      if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+        Security.addProvider(new BouncyCastleProvider());
+      }
+      pushService = new PushService(vapidPublicKey, vapidPrivateKey, vapidSubject);
+      pushEnabled = true;
+      log.info("Push notification service initialized");
+    } catch (Exception e) {
+      log.warn("Failed to initialize push service: {}", e.getMessage());
+    }
+  }
+
+  public boolean isPushEnabled() {
+    return pushEnabled;
+  }
+
+  public void send(PushSubscription subscription, String title, String body) {
+    if (!pushEnabled) return;
+    try {
+      var payload =
+          objectMapper.writeValueAsString(
+              Map.of("title", title, "body", body, "icon", "/logo.png"));
+      var notification =
+          new Notification(
+              subscription.getEndpoint(),
+              subscription.getP256dh(),
+              subscription.getAuthKey(),
+              payload.getBytes());
+      pushService.send(notification);
+    } catch (Exception e) {
+      log.warn(
+          "Push failed for user={} endpoint={}: {}",
+          subscription.getUserId(),
+          subscription.getEndpoint(),
+          e.getMessage());
+    }
+  }
+}

--- a/services/questify-notification-service/src/main/resources/application.properties
+++ b/services/questify-notification-service/src/main/resources/application.properties
@@ -1,0 +1,38 @@
+spring.application.name=questify-notification-service
+server.port=8087
+
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/questify}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:notification_svc}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:notification_svc}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.default_schema=notifications
+spring.jpa.open-in-view=false
+spring.jpa.show-sql=false
+
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:sql/schema.sql
+
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${RABBITMQ_USERNAME:questify}
+spring.rabbitmq.password=${RABBITMQ_PASSWORD:questify}
+
+questify.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:80}
+
+# Reminder scheduler: check every 15 minutes
+questify.reminder.check-delay-ms=${REMINDER_CHECK_DELAY_MS:900000}
+# Remind N hours before due date
+questify.reminder.hours-before=${REMINDER_HOURS_BEFORE:24}
+# Max in-app notifications retained per user
+questify.notification.max-per-user=${NOTIFICATION_MAX_PER_USER:100}
+
+# VAPID keys for web push (leave blank to disable push)
+vapid.public-key=${VAPID_PUBLIC_KEY:}
+vapid.private-key=${VAPID_PRIVATE_KEY:}
+vapid.subject=${VAPID_SUBJECT:mailto:admin@questify.local}
+
+management.health.rabbit.enabled=false
+management.endpoints.web.exposure.include=health,prometheus
+management.endpoint.health.show-details=when_authorized
+management.metrics.tags.application=${spring.application.name}

--- a/services/questify-notification-service/src/main/resources/sql/schema.sql
+++ b/services/questify-notification-service/src/main/resources/sql/schema.sql
@@ -1,0 +1,49 @@
+CREATE SCHEMA IF NOT EXISTS notifications;
+
+CREATE TABLE IF NOT EXISTS notifications.notifications
+(
+    id         UUID PRIMARY KEY     DEFAULT gen_random_uuid(),
+    user_id    UUID        NOT NULL,
+    type       VARCHAR(50) NOT NULL,
+    title      TEXT        NOT NULL,
+    body       TEXT        NOT NULL,
+    quest_id   UUID,
+    read       BOOLEAN     NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_unread
+    ON notifications.notifications (user_id, read, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS notifications.scheduled_reminders
+(
+    id             UUID PRIMARY KEY     DEFAULT gen_random_uuid(),
+    user_id        UUID        NOT NULL,
+    template_id    UUID        NOT NULL,
+    occurrence_id  UUID,
+    quest_title    TEXT        NOT NULL,
+    scheduled_date DATE        NOT NULL,
+    reminder_sent  BOOLEAN     NOT NULL DEFAULT false,
+    completed      BOOLEAN     NOT NULL DEFAULT false,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (user_id, occurrence_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_reminders_pending
+    ON notifications.scheduled_reminders (scheduled_date, reminder_sent, completed)
+    WHERE reminder_sent = false AND completed = false;
+
+CREATE TABLE IF NOT EXISTS notifications.push_subscriptions
+(
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID NOT NULL,
+    endpoint   TEXT NOT NULL,
+    p256dh     TEXT NOT NULL,
+    auth_key   TEXT NOT NULL,
+    created_at TIMESTAMPTZ      DEFAULT now(),
+    UNIQUE (user_id, endpoint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_user
+    ON notifications.push_subscriptions (user_id);

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QuestEventPublisher.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QuestEventPublisher.java
@@ -5,6 +5,7 @@ import com.axelfrache.questify.quest.repository.OutboxEventRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,28 @@ public class QuestEventPublisher {
           xpEarned);
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize QuestCompletedEvent", e);
+    }
+  }
+
+  public void publishQuestScheduled(
+      UUID userId, UUID templateId, UUID occurrenceId, String questTitle, LocalDate scheduledDate) {
+    var event =
+        new QuestScheduledEvent(
+            userId, templateId, occurrenceId, questTitle, scheduledDate.toString());
+    try {
+      outboxEventRepository.save(
+          OutboxEvent.builder()
+              .routingKey(QueueConstants.QUEST_SCHEDULED_ROUTING_KEY)
+              .payload(objectMapper.writeValueAsString(event))
+              .typeId(QuestScheduledEvent.class.getName())
+              .build());
+      log.debug(
+          "Queued QuestScheduledEvent to outbox: userId={} occurrenceId={} date={}",
+          userId,
+          occurrenceId,
+          scheduledDate);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize QuestScheduledEvent", e);
     }
   }
 }

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QuestScheduledEvent.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QuestScheduledEvent.java
@@ -1,0 +1,10 @@
+package com.axelfrache.questify.quest.messaging;
+
+import java.util.UUID;
+
+public record QuestScheduledEvent(
+    UUID userId,
+    UUID templateId,
+    UUID occurrenceId,
+    String questTitle,
+    String scheduledDate) {}

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QuestScheduledEvent.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QuestScheduledEvent.java
@@ -3,8 +3,4 @@ package com.axelfrache.questify.quest.messaging;
 import java.util.UUID;
 
 public record QuestScheduledEvent(
-    UUID userId,
-    UUID templateId,
-    UUID occurrenceId,
-    String questTitle,
-    String scheduledDate) {}
+    UUID userId, UUID templateId, UUID occurrenceId, String questTitle, String scheduledDate) {}

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QueueConstants.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/messaging/QueueConstants.java
@@ -8,6 +8,7 @@ public final class QueueConstants {
   public static final String USER_REGISTERED_ROUTING_KEY = "user.registered";
   public static final String USER_DELETED_ROUTING_KEY = "user.deleted";
   public static final String QUEST_COMPLETED_ROUTING_KEY = "quest.completed";
+  public static final String QUEST_SCHEDULED_ROUTING_KEY = "quest.scheduled";
   public static final String PROJECT_DELETED_ROUTING_KEY = "project.deleted";
   public static final String QUEST_COMPLETED_QUEUE = "quest-service.quest-completed";
   public static final String USER_REGISTERED_QUEST_QUEUE = "quest-service.user-registered";

--- a/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/service/QuestService.java
+++ b/services/questify-quest-service/src/main/java/com/axelfrache/questify/quest/service/QuestService.java
@@ -102,6 +102,8 @@ public class QuestService {
                 .hasDueDate(true)
                 .build();
         questOccurrenceRepository.save(occurrence);
+        questEventPublisher.publishQuestScheduled(
+            userId, template.getId(), occurrence.getId(), template.getTitle(), scheduledDate);
         return toResponse(occurrence);
       }
       return toResponse(template);
@@ -121,7 +123,14 @@ public class QuestService {
         if (occurrence.getStatus() != QuestStatus.PENDING)
           throw new IllegalStateException(
               "Cannot update the due date of a completed or cancelled quest occurrence");
-        occurrence.setScheduledDate(request.dueDate().atZone(ZoneOffset.UTC).toLocalDate());
+        var newDate = request.dueDate().atZone(ZoneOffset.UTC).toLocalDate();
+        occurrence.setScheduledDate(newDate);
+        questEventPublisher.publishQuestScheduled(
+            userId,
+            occurrence.getQuestTemplate().getId(),
+            occurrence.getId(),
+            occurrence.getQuestTemplate().getTitle(),
+            newDate);
       }
 
       var template = occurrence.getQuestTemplate();
@@ -166,6 +175,12 @@ public class QuestService {
                         .hasDueDate(true)
                         .build();
                 questOccurrenceRepository.save(occurrence);
+                questEventPublisher.publishQuestScheduled(
+                    userId,
+                    template.getId(),
+                    occurrence.getId(),
+                    template.getTitle(),
+                    scheduledDate);
                 return toResponse(occurrence);
               });
     }


### PR DESCRIPTION
Introduces a new questify-notification-service (port 8087) handling in-app notifications and WebPush reminders for quests with due dates.

## notification-service

- **3 tables**:
  - `notifications`
  - `scheduled_reminders`
  - `push_subscriptions`

- **Event listeners**:
  - `quest.scheduled` → stores reminder
  - `quest.completed` → clears reminder + sends congratulations notification
  - `user.deleted` → full cleanup

- **ReminderScheduler**:
  - Runs every 15 minutes
  - Creates `QUEST_DUE_SOON` / `QUEST_OVERDUE` notifications
  - Fires WebPush notifications if VAPID keys are configured

- **REST endpoints**:
  - List notifications
  - Read notification
  - Mark all as read
  - Delete notification
  - Push subscribe / unsubscribe
  - Push status

- **Push configuration**:
  - Push is disabled gracefully when `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` are not set